### PR TITLE
Added 'git@' to the automatic identification of the source

### DIFF
--- a/snapcraft/sources.py
+++ b/snapcraft/sources.py
@@ -294,7 +294,7 @@ def _get_source_type_from_uri(source):
     source_type = ''
     if source.startswith("bzr:") or source.startswith("lp:"):
         source_type = 'bzr'
-    elif source.startswith("git:"):
+    elif source.startswith("git:") or source.startswith("git@"):
         source_type = 'git'
     elif _tar_type_regex.match(source):
         source_type = 'tar'


### PR DESCRIPTION
Many people use git over SSH, so using "git@" to identify a git repository helps the developer a little bit.