### PR TITLE
Remove ubuntu pacakges from the list

### DIFF
--- a/snapcraft/plugins/qml.py
+++ b/snapcraft/plugins/qml.py
@@ -58,9 +58,6 @@ class QmlPlugin(snapcraft.BasePlugin):
             "qml-module-qtsysteminfo",
             "qml-module-qttest",
             "qml-module-qtwebkit",
-            "qml-module-ubuntu-connectivity",
-            "qml-module-ubuntu-onlineaccounts",
-            "qml-module-ubuntu-onlineaccounts-client",
         ])
 
     def snap_fileset(self):


### PR DESCRIPTION
We can't have any ubuntu packages here, they start to pull in all the desktop frameworks. These three quite literally double the size of the snap and the number of packages.