### PR TITLE
Catch the correct exception for missing catkin pkg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   # PPA for snappy.
   - sudo apt-add-repository -y ppa:snappy-dev/tools-proposed
   - sudo apt-get update -qq
-  - sudo apt-get install -qq build-essential dpkg-dev plainbox pyflakes python3-apt python3-coverage python3-fixtures python3-jsonschema python3-mccabe python3-pep8 python3-requests python3-testscenarios python3-yaml ubuntu-snappy-cli
+  - sudo apt-get install -qq build-essential dpkg-dev plainbox pyflakes python3-apt python3-coverage python3-fixtures python3-jsonschema python3-mccabe python3-pep8 python3-requests python3-testscenarios python3-yaml ubuntu-snappy-cli python3-lxml
 script:
   - ./runtests.sh $TEST_SUITE
 after_success:

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -38,7 +38,7 @@ import snapcraft.repo
 logger = logging.getLogger(__name__)
 
 
-class CatkinPlugin (snapcraft.BasePlugin):
+class CatkinPlugin(snapcraft.BasePlugin):
 
     _PLUGIN_STAGE_SOURCES = '''
 deb http://packages.ros.org/ros/ubuntu/ trusty main
@@ -170,9 +170,12 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
                     self.builddir, 'src', pkg, 'package.xml')
                 with open(filename, 'r') as f:
                     self._deps_from_packagesxml(f, pkg)
-            except os.FileNotFound:
-                logger.warning('Unable to find packages.xml for "' + pkg + '"')
-                pass
+            except IOError as e:
+                if e.errno is os.errno.ENOENT:
+                    logger.warning(
+                        'Unable to find packages.xml for "{}"'.format(pkg))
+                else:
+                    raise e
 
         self.package_deps_found = True
 

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fixtures
+import os
+import os.path
+
+from unittest import mock
+
+from snapcraft import tests
+from snapcraft.plugins import catkin
+
+
+class _IOError(IOError):
+    errno = os.errno.EACCES
+
+
+class CatkinTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class props:
+            catkin_packages = ['my_package']
+
+        self.properties = props()
+
+    def test_log_warning_when_unable_to_find_a_catkin_package(self):
+        fake_logger = fixtures.FakeLogger()
+        self.useFixture(fake_logger)
+
+        plugin = catkin.CatkinPlugin('test-part', self.properties)
+        plugin._find_package_deps()
+
+        self.assertEqual('Unable to find packages.xml for "my_package"\n',
+                         fake_logger.output)
+
+    @mock.patch('snapcraft.plugins.catkin.open', create=True)
+    def test_exception_raised_when_package_definition_cannot_be_read(
+            self, mock_open):
+        mock_open.side_effect = _IOError()
+        plugin = catkin.CatkinPlugin('test-part', self.properties)
+        with self.assertRaises(IOError) as raised:
+            plugin._find_package_deps()
+
+        self.assertEqual(raised.exception.errno, os.errno.EACCES)
+        xml_to_open = os.path.join(
+            os.path.abspath(os.curdir), 'parts', 'test-part', 'build', 'src',
+            'my_package', 'package.xml')
+        mock_open.assert_called_once_with(xml_to_open, 'r')


### PR DESCRIPTION
When a catking package is not found, the incorrect exception is captured.

This fixes issue #66

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>