### PR TITLE
Making source management common to all types

### DIFF
--- a/integration-tests/units/jobs.pxu
+++ b/integration-tests/units/jobs.pxu
@@ -94,10 +94,9 @@ command:
     set -ex
     cp -rT $PLAINBOX_PROVIDER_DATA/local-source .
     ${SNAPCRAFT} build
-    test -e stamp-all
-    test "$(readlink parts/make-project/build)" = "$(pwd)"
+    test -e parts/make-project/build/stamp-all
     ${SNAPCRAFT} stage
-    test -e stamp-install
+    test -e parts/make-project/build/stamp-install
 flags: simple has-leftovers
 
 id: snapcraft/normal/local-plugin

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -113,6 +113,7 @@ be used in any part irrespective of the plugin, these are
 
 import contextlib
 import os
+import shutil
 
 import snapcraft.common
 import snapcraft.sources
@@ -206,10 +207,15 @@ class BasePlugin:
     def build(self):
         """Build the source code retrieved from the pull phase.
 
-        The base implementation does nothing by default. Override this
-        method if you need to process the source code to make it runnable.
+        The base implementation only copies sourcedir to builddir. Override
+        this method if you need to process the source code to make it runnable.
         """
-        pass
+        if os.path.exists(self.builddir):
+            shutil.rmtree(self.builddir)
+        shutil.copytree(
+            self.sourcedir, self.builddir,
+            ignore=lambda d, s: snapcraft.common.SNAPCRAFT_FILES
+            if d is self.sourcedir else [])
 
     def snap_fileset(self):
         """Return a list of files to include or exclude in the resulting snap

--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -23,6 +23,7 @@ import tempfile
 import urllib
 
 
+SNAPCRAFT_FILES = ['snapcraft.yaml', 'parts', 'stage', 'snap']
 COMMAND_ORDER = ['pull', 'build', 'stage', 'snap']
 _DEFAULT_PLUGINDIR = '/usr/share/snapcraft/plugins'
 _plugindir = _DEFAULT_PLUGINDIR

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -65,6 +65,7 @@ class AutotoolsPlugin(MakePlugin):
         ])
 
     def build(self):
+        super().build()
         if not os.path.exists(os.path.join(self.builddir, "configure")):
             if os.path.exists(os.path.join(self.builddir, "autogen.sh")):
                 self.run(['env', 'NOCONFIGURE=1', './autogen.sh'],
@@ -73,4 +74,4 @@ class AutotoolsPlugin(MakePlugin):
                 self.run(['autoreconf', '-i'], cwd=self.builddir)
         self.run(['./configure', '--prefix='] +
                  self.options.configflags)
-        super().build()
+        self.run(['make', 'install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -31,6 +31,7 @@ import lxml.etree
 import os
 import tempfile
 import logging
+import shutil
 
 import snapcraft
 import snapcraft.repo
@@ -197,6 +198,17 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             self.run(['/bin/bash', f.name], cwd=cwd)
 
     def build(self):
+        if os.path.exists(os.path.join(self.sourcedir, 'src')):
+            super().build()
+        else:
+            if os.path.exists(self.builddir):
+                shutil.rmtree(self.builddir)
+            dst = os.path.join(self.builddir, 'src')
+            shutil.copytree(
+                self.sourcedir, dst,
+                ignore=lambda d, s: snapcraft.common.SNAPCRAFT_FILES
+                if d is self.sourcedir else [])
+
         # Fixup ROS Cmake files that have hardcoded paths in them
         self.run([
             'find', self.rosdir, '-name', '*.cmake',

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -30,6 +30,9 @@ Additionally, this plugin uses the following plugin specific keywords:
       configure flags to pass to the build using the common cmake semantics.
 """
 
+import os
+import shutil
+
 import snapcraft.plugins.make
 
 
@@ -55,6 +58,8 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
         self.build_packages.append('cmake')
 
     def build(self):
-        self.run(['cmake', '.', '-DCMAKE_INSTALL_PREFIX='] +
+        if os.path.exists(self.builddir):
+            shutil.rmtree(self.builddir)
+        self.run(['cmake', self.sourcedir, '-DCMAKE_INSTALL_PREFIX='] +
                  self.options.configflags)
-        super().build()
+        self.run(['make', 'install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -34,5 +34,6 @@ class MakePlugin(snapcraft.BasePlugin):
         self.build_packages.append('make')
 
     def build(self):
+        super().build()
         self.run(['make'])
         self.run(['make', 'install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -101,9 +101,10 @@ class Python2Plugin(snapcraft.BasePlugin):
             self.run(pip_install + ['--requirement', requirements])
 
         if os.path.exists(setup):
-            self.run(pip_install + ['.', ])
+            self.run(pip_install + ['.', ], cwd=self.sourcedir)
 
     def build(self):
+        super().build()
         # If setuptools is used, it tries to create files in the
         # dist-packages dir and import from there, so it needs to exist
         # and be in the PYTHONPATH. It's harmless if setuptools isn't

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -100,9 +100,11 @@ class Python3Plugin(snapcraft.BasePlugin):
             self.run(pip_install + ['--requirement', requirements])
 
         if os.path.exists(setup):
-            self.run(pip_install + ['.', ])
+            self.run(pip_install + ['.', ], cwd=self.sourcedir)
 
     def build(self):
+        super().build()
+
         # If setuptools is used, it tries to create files in the
         # dist-packages dir and import from there, so it needs to exist
         # and be in the PYTHONPATH. It's harmless if setuptools isn't

--- a/snapcraft/plugins/scons.py
+++ b/snapcraft/plugins/scons.py
@@ -56,6 +56,7 @@ class SconsPlugin(snapcraft.BasePlugin):
         self.build_packages.append('scons')
 
     def build(self):
+        super().build()
         env = os.environ.copy()
         env['DESTDIR'] = self.installdir
         self.run(['scons', ] + self.options.scons_options)


### PR DESCRIPTION
This makes source handling common for all source types, leaving
the source in sourcedir always and leaving the logic to manage
build from the plugin.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>