### PR TITLE
Don't throw exception on snapcraft run exit status

### DIFF
--- a/snapcraft/cmds.py
+++ b/snapcraft/cmds.py
@@ -229,7 +229,7 @@ def run(args):
             ['ssh'] + ssh_opts +
             ['ubuntu@localhost', '-p', '8022', 'sudo snappy install  *.snap'])
         # "login"
-        _check_call(
+        _call(
             ['ssh'] + ssh_opts + ['-p', '8022', 'ubuntu@localhost'],
             preexec_fn=os.setsid)
     finally:


### PR DESCRIPTION
If the last command executed in a snapcraft run session exits with a
non-zero status, an exception will be raised because we were using
check_call. Don't check the return value here so that we exit cleanly
rather than making it look like something horrible happened.

Fixed #40