### PR TITLE
Clean for parts and removal of duped code for lifecycle and the BasePlugin

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -115,9 +115,8 @@ import contextlib
 import os
 import shutil
 
-import snapcraft.common
-import snapcraft.sources
-import snapcraft.repo
+from snapcraft import common
+from snapcraft import sources
 
 
 class BasePlugin:
@@ -173,15 +172,10 @@ class BasePlugin:
             self.build_packages = options.build_packages
 
         self.options = options
-        self.partdir = os.path.join(os.getcwd(), 'parts', self.name)
-        self.sourcedir = os.path.join(os.getcwd(), 'parts', self.name, 'src')
-        self.builddir = os.path.join(os.getcwd(), 'parts', self.name, 'build')
-        self.ubuntudir = os.path.join(os.getcwd(), 'parts', self.name,
-                                      'ubuntu')
-        self.installdir = os.path.join(os.getcwd(), 'parts', self.name,
-                                       'install')
-        self.stagedir = os.path.join(os.getcwd(), 'stage')
-        self.snapdir = os.path.join(os.getcwd(), 'snap')
+        self.partdir = os.path.join(common.get_partsdir(), self.name)
+        self.sourcedir = os.path.join(self.partdir, 'src')
+        self.builddir = os.path.join(self.partdir, 'build')
+        self.installdir = os.path.join(self.partdir, 'install')
 
     # The API
     def pull(self):
@@ -201,8 +195,7 @@ class BasePlugin:
         enhance with custom pull logic.
         """
         if getattr(self.options, 'source', None):
-            snapcraft.sources.get(
-                self.sourcedir, self.builddir, self.options)
+            sources.get(self.sourcedir, self.builddir, self.options)
 
     def build(self):
         """Build the source code retrieved from the pull phase.
@@ -214,7 +207,7 @@ class BasePlugin:
             shutil.rmtree(self.builddir)
         shutil.copytree(
             self.sourcedir, self.builddir, symlinks=True,
-            ignore=lambda d, s: snapcraft.common.SNAPCRAFT_FILES
+            ignore=lambda d, s: common.SNAPCRAFT_FILES
             if d is self.sourcedir else [])
 
     def snap_fileset(self):
@@ -256,7 +249,7 @@ class BasePlugin:
         if True:
             print(' '.join(cmd))
         os.makedirs(cwd, exist_ok=True)
-        return snapcraft.common.run(cmd, cwd=cwd, **kwargs)
+        return common.run(cmd, cwd=cwd, **kwargs)
 
     def run_output(self, cmd, cwd=None, **kwargs):
         if cwd is None:
@@ -264,4 +257,4 @@ class BasePlugin:
         if True:
             print(' '.join(cmd))
         os.makedirs(cwd, exist_ok=True)
-        return snapcraft.common.run_output(cmd, cwd=cwd, **kwargs)
+        return common.run_output(cmd, cwd=cwd, **kwargs)

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -93,6 +93,8 @@ def main():
         'clean',
         help='clean up the environment (to start from scratch)')
     parser.set_defaults(func=snapcraft.cmds.clean)
+    parser.add_argument('parts', nargs='*', metavar='PART',
+                        help='specific part to clean')
 
     parser = subparsers.add_parser('pull', help='get sources',
                                    parents=[cmd_parser])

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -34,7 +34,7 @@ import logging
 import shutil
 
 import snapcraft
-import snapcraft.repo
+from snapcraft import repo
 
 logger = logging.getLogger(__name__)
 
@@ -185,9 +185,10 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
     def _setup_deb_packages(self):
         self._find_package_deps()
 
+        ubuntudir = os.path.join(self.partdir, 'ubuntu')
+        os.makedirs(ubuntudir, exist_ok=True)
         if self._deb_packages:
-            ubuntu = snapcraft.repo.Ubuntu(
-                self.ubuntudir, sources=self.PLUGIN_STAGE_SOURCES)
+            ubuntu = repo.Ubuntu(ubuntudir, sources=self.PLUGIN_STAGE_SOURCES)
             ubuntu.get(self._deb_packages)
             ubuntu.unpack(self.installdir)
 

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -265,3 +265,39 @@ class PluginMakedirsTestCase(snapcraft.tests.TestCase):
         p.makedirs()
         for d in dirs:
             self.assertTrue(os.path.exists(d), '{} does not exist'.format(d))
+
+
+class CleanTestCase(snapcraft.tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        common.set_schemadir(os.path.join(__file__,
+                             '..', '..', '..', 'schema'))
+
+    @patch('shutil.rmtree')
+    @patch('os.path.exists')
+    def test_clean_part_that_exists(self, mock_exists, mock_rmtree):
+        mock_exists.return_value = True
+
+        part_name = 'test_part'
+        p = get_test_plugin(part_name=part_name)
+        p.clean()
+
+        partdir = os.path.join(
+            os.path.abspath(os.curdir), 'parts', part_name)
+        mock_exists.assert_called_once_with(partdir)
+        mock_rmtree.assert_called_once_with(partdir)
+
+    @patch('shutil.rmtree')
+    @patch('os.path.exists')
+    def test_clean_part_already_clean(self, mock_exists, mock_rmtree):
+        mock_exists.return_value = False
+
+        part_name = 'test_part'
+        p = get_test_plugin(part_name=part_name)
+        p.clean()
+
+        partdir = os.path.join(
+            os.path.abspath(os.curdir), 'parts', part_name)
+        mock_exists.assert_called_once_with(partdir)
+        self.assertFalse(mock_rmtree.called)


### PR DESCRIPTION
Parts can now be individually cleaned up, involved moving some
of the logic to the plugin handler in the lifecycle itself.

Define things in one place only and expose them accordingly.

sourcedir, builddir and installdir are handled in the plugin while
stagedir, snapdir, ubuntudir and the state file by the lifecycle.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>