### PR TITLE
Stage packages preferred over ./install and system

### DIFF
--- a/examples/py2-project/snapcraft.yaml
+++ b/examples/py2-project/snapcraft.yaml
@@ -8,9 +8,6 @@ summary: A python sha3 implementation
 description: A python2 project using snapcraft
 icon: icon.png
 
-build-packages:
-  - libpython2.7-dev
-
 parts:
   spongeshaker:
     plugin: python2

--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -107,8 +107,12 @@ class Python2Plugin(snapcraft.BasePlugin):
         self.run(['python2', easy_install, '--prefix', prefix, 'pip'])
 
         pip2 = os.path.join(self.installdir, 'usr', 'bin', 'pip2')
-        pip_install = ['python2', pip2, 'install', '--target',
-                       site_packages_dir]
+        pip_install = ['python2', pip2, 'install',
+                       '--global-option=build_ext',
+                       '--global-option=-I{}'.format(os.path.join(
+                           self.installdir, 'usr', 'include', '{}'.format(
+                               self.python_version))),
+                       '--target', site_packages_dir]
 
         if self.options.requirements:
             self.run(pip_install + ['--requirement', requirements])
@@ -133,8 +137,13 @@ class Python2Plugin(snapcraft.BasePlugin):
         os.makedirs(self.dist_packages_dir, exist_ok=True)
         setuptemp = self.copy_setup()
         self.run(
-            ['python2', setuptemp.name, 'install', '--install-layout=deb',
-             '--prefix={}/usr'.format(self.installdir)], cwd=self.builddir)
+            ['python2', setuptemp.name,
+             'build_ext', '-I{}'.format(os.path.join(
+                 self.installdir, 'usr', 'include', '{}'.format(
+                     self.python_version))),
+             'install', '--install-layout=deb',
+             '--prefix={}/usr'.format(self.installdir),
+             ], cwd=self.builddir)
 
     @property
     def dist_packages_dir(self):
@@ -144,7 +153,7 @@ class Python2Plugin(snapcraft.BasePlugin):
 
     @property
     def python_version(self):
-        return self.run_output(['pyversions', '-i'])
+        return self.run_output(['pyversions', '-d'])
 
     # Takes the setup.py file and puts a couple little gems on the
     # front to make things work better.

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -144,7 +144,7 @@ class Python3Plugin(snapcraft.BasePlugin):
 
     @property
     def python_version(self):
-        return self.run_output(['py3versions', '-i']).split()[0]
+        return self.run_output(['py3versions', '-d'])
 
     # Takes the setup.py file and puts a couple little gems on the
     # front to make things work better.

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -247,19 +247,23 @@ class Config:
         env.append('PERL5LIB={0}/usr/share/perl5/'.format(root))
         return env
 
-    def build_env_for_part(self, part):
-        # Grab build env of all part's dependencies
+    def build_env_for_part(self, part, root_part=True):
+        """Return a build env of all the part's dependencies."""
 
         env = []
+        stagedir = snapcraft.common.get_stagedir()
+        for dep_part in part.deps:
+            env += dep_part.env(stagedir)
+            env += self.build_env_for_part(dep_part, root_part=False)
 
-        for dep in part.deps:
-            root = dep.installdir
-            env += dep.env(root)
-            env += self.build_env_for_part(dep)
-
-        env += part.env(part.installdir)
-        env += self.runtime_env(part.installdir)
-        env += self.build_env(part.installdir)
+        if root_part:
+            env += part.env(part.installdir)
+            env += self.runtime_env(part.installdir)
+            env += self.build_env(part.installdir)
+        else:
+            env += part.env(stagedir)
+            env += self.runtime_env(stagedir)
+            env += self.build_env(stagedir)
 
         return env
 


### PR DESCRIPTION
When building there has been this long time issue of reaching into
each parts part/<part-name>/install directory, this breaks part
encapsulation. If anything, the build paths should point to the
stage directory and should be used in combination with the `after`
keyword.

Additionally, python2 needed some help include path mangling to
find its own Python.h

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>