### PR TITLE
Validate that 'plugins' is not used as a part name

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -99,7 +99,7 @@ properties:
     minProperties: 1
     additionalProperties: false
     patternProperties:
-      ^[a-z0-9][a-z0-9+-]*$:
+      ^(?!plugins$)[a-z0-9][a-z0-9+-]*$:
         type: object
         properties:
           plugin:
@@ -154,9 +154,6 @@ properties:
             items:
               type: string
             default: ['*']
-        # required:
-        # - plugin
-        # - source
 required:
   - name
   - version

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -542,6 +542,17 @@ class TestValidation(TestCase):
         self.assertEqual(raised.exception.message, expected_message,
                          msg=self.data)
 
+    def test_invalid_part_name_plugin_raises_exception(self):
+        self.data['parts']['plugins'] = {'type': 'go'}
+
+        with self.assertRaises(snapcraft.yaml.SnapcraftSchemaError) as raised:
+            snapcraft.yaml._validate_snapcraft_yaml(self.data)
+
+        expected_message = 'Additional properties are not allowed ' \
+                           '(\'plugins\' was unexpected)'
+        self.assertEqual(raised.exception.message, expected_message,
+                         msg=self.data)
+
 
 class TestFilesets(TestCase):
 


### PR DESCRIPTION
parts/plugins has a special meaning and it should not be used for
part names as it can cause potential issues when working with
local plugins.

Some commented schema yaml was removed too.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>