### PR TITLE
go plugin: Support local sources

### DIFF
--- a/examples/gopaste/snapcraft.yaml
+++ b/examples/gopaste/snapcraft.yaml
@@ -12,4 +12,5 @@ icon: icon.png
 parts:
   gopaste:
     plugin: go
-    source: git://github.com/wisnij/gopaste/gopasted
+    source: https://github.com/wisnij/gopaste.git
+    source-type: git

--- a/integration-tests/data/simple-go/main.go
+++ b/integration-tests/data/simple-go/main.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+    "fmt"
+)
+
+func main() {
+    fmt.Println("Hello snapcrafter")
+}

--- a/integration-tests/data/simple-go/snapcraft.yaml
+++ b/integration-tests/data/simple-go/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: test-package
+version: 0.1
+vendor: Sergio Schvezov <sergio.schvezov@canonical.com>
+summary: A simple go project.
+description: |
+  Proves that it is possible to build a snap using local go sources.
+  The name of the binary will be that of the directory containing it,
+  just like it is seen when using `go build` or `go install`.
+icon: icon.png
+
+parts:
+  simple-go:
+    plugin: go
+    source: .

--- a/integration-tests/units/jobs.pxu
+++ b/integration-tests/units/jobs.pxu
@@ -220,6 +220,14 @@ command:
     ${SNAPCRAFT} clean
 flags: simple has-leftovers
 
+id: snapcraft/normal/simple-go
+command:
+    set -ex
+    cp -rT $PLAINBOX_PROVIDER_DATA/simple-go .
+    ${SNAPCRAFT} stage
+    test "$(./stage/bin/$(basename $(pwd)))" = "Hello snapcrafter"
+flags: simple has-leftovers
+
 id: snapcraft/normal/simple-cmake
 command:
     set -ex

--- a/snapcraft/tests/test_plugin_go.py
+++ b/snapcraft/tests/test_plugin_go.py
@@ -14,11 +14,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
+from unittest import mock
+
 from snapcraft.plugins import go
 from snapcraft import tests
 
 
 class GoPluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('snapcraft.common.run')
+        self.run_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('sys.stdout')
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_environment(self):
         class Options:
@@ -30,3 +45,86 @@ class GoPluginTestCase(tests.TestCase):
             'CGO_LDFLAGS=$CGO_LDFLAGS"-Lmyroot/lib -Lmyroot/usr/lib '
             '-Lmyroot/lib/x86_64-linux-gnu '
             '-Lmyroot/usr/lib/x86_64-linux-gnu $LDFLAGS"'])
+
+    def test_pull_local_sources(self):
+        class Options:
+            source = 'dir'
+
+        plugin = go.GoPlugin('test-part', Options())
+
+        os.makedirs(plugin.options.source)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.pull()
+
+        self.run_mock.assert_has_calls([
+            mock.call(['env', 'GOPATH={}'.format(plugin._gopath),
+                       'go', 'get', '-t', '-d', './dir/...'],
+                      cwd=plugin._gopath_src)])
+
+        self.assertTrue(os.path.exists(plugin._gopath))
+        self.assertTrue(os.path.exists(plugin._gopath_src))
+        self.assertFalse(os.path.exists(plugin._gopath_bin))
+
+    def test_pull_with_no_local_sources(self):
+        class Options:
+            source = None
+
+        plugin = go.GoPlugin('test-part', Options())
+        plugin.pull()
+
+        self.run_mock.assert_has_calls([])
+
+        self.assertTrue(os.path.exists(plugin._gopath))
+        self.assertTrue(os.path.exists(plugin._gopath_src))
+        self.assertFalse(os.path.exists(plugin._gopath_bin))
+
+    def test_build_with_local_sources(self):
+        class Options:
+            source = 'dir'
+
+        plugin = go.GoPlugin('test-part', Options())
+
+        os.makedirs(plugin.options.source)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.pull()
+
+        os.makedirs(plugin._gopath_bin)
+        os.makedirs(plugin.builddir)
+
+        plugin.build()
+
+        self.run_mock.assert_has_calls([
+            mock.call(['env', 'GOPATH={}'.format(plugin._gopath),
+                       'go', 'get', '-t', '-d', './dir/...'],
+                      cwd=plugin._gopath_src),
+            mock.call(['env', 'GOPATH={}'.format(plugin._gopath),
+                       'go', 'install', './dir/...'],
+                      cwd=plugin._gopath_src),
+        ])
+
+        self.assertTrue(os.path.exists(plugin._gopath))
+        self.assertTrue(os.path.exists(plugin._gopath_src))
+        self.assertTrue(os.path.exists(plugin._gopath_bin))
+
+    def test_build_with_no_local_sources(self):
+        class Options:
+            source = None
+
+        plugin = go.GoPlugin('test-part', Options())
+
+        os.makedirs(plugin.sourcedir)
+
+        plugin.pull()
+
+        os.makedirs(plugin._gopath_bin)
+        os.makedirs(plugin.builddir)
+
+        plugin.build()
+
+        self.run_mock.assert_has_calls([])
+
+        self.assertTrue(os.path.exists(plugin._gopath))
+        self.assertTrue(os.path.exists(plugin._gopath_src))
+        self.assertTrue(os.path.exists(plugin._gopath_bin))


### PR DESCRIPTION
This also avoids the error of checking for `:` in self.options.source

Closes LP: #1499240
Closes LP: #1515132

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>