### PR TITLE
Docstring polish: inserting a - between words

### DIFF
--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -26,7 +26,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-In additon, this plugin uses the following plugin specific keywords:
+In additon, this plugin uses the following plugin-specific keywords:
 
     - configflags:
       (list of strings)

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -20,7 +20,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - catkin-packages:
       (list of strings)

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -23,7 +23,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - configflags:
       (list of strings)

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -23,7 +23,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - go-packages:
       (list of strings)

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -23,7 +23,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - maven-options:
       (list of strings)

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -23,7 +23,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - node-packages:
       (list)

--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -27,7 +27,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - requirements:
       (string)

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -27,7 +27,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - requirements:
       (string)

--- a/snapcraft/plugins/scons.py
+++ b/snapcraft/plugins/scons.py
@@ -22,7 +22,7 @@ This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
 
-Additionally, this plugin uses the following plugin specific keywords:
+Additionally, this plugin uses the following plugin-specific keywords:
 
     - scons-options:
       (list of strings)


### PR DESCRIPTION
So it reads *plugin-specific* instead of *plugin specific*

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>