### PR TITLE
Removed restriction on underscores in binary and service names

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,7 +63,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      "^[A-Za-z0-9:-_]*$":
+      "^[A-Za-z0-9:_-]*$":
         type: object
         required:
           - start
@@ -82,7 +82,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      "^[A-Za-z0-9:-_]*$":
+      "^[A-Za-z0-9:_-]*$":
         type: object
         required:
           - exec

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,7 +63,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      "^[A-Za-z0-9:-]*$":
+      "^[A-Za-z0-9:-_]*$":
         type: object
         required:
           - start
@@ -82,7 +82,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      "^[A-Za-z0-9:-]*$":
+      "^[A-Za-z0-9:-_]*$":
         type: object
         required:
           - exec

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -464,7 +464,6 @@ class TestValidation(TestCase):
     def test_invalid_binary_names(self):
         invalid_names = {
             'qwe#rty': {'exec': '1'},
-            'qwe_rty': {'exec': '1'},
             'que rty': {'exec': '1'},
             'que  rty': {'exec': '1'},
         }
@@ -486,8 +485,7 @@ class TestValidation(TestCase):
     def test_invalid_service_names(self):
         invalid_names = {
             'qwe#rty': {'start': '1'},
-            'qwe_rty': {'start': '1'},
-            'que_rty': {'start': '1'},
+            'que rty': {'start': '1'},
             'quer  ty': {'start': '1'},
         }
 


### PR DESCRIPTION
Modified regex to allow underscores in binary and service names. I'm not sure if there is a reason for this restriction, but it prevents me from using some Postgres binaries.