### PR TITLE
Fix webcam example

### DIFF
--- a/examples/webcam-webui/snapcraft.yaml
+++ b/examples/webcam-webui/snapcraft.yaml
@@ -35,5 +35,5 @@ parts:
     files:
       webcam-webui: bin/webcam-webui
   config:
-    plugin: python3-project
+    plugin: python3
     source: .

--- a/examples/webcam-webui/snapcraft.yaml
+++ b/examples/webcam-webui/snapcraft.yaml
@@ -6,6 +6,7 @@ description: Exposes your webcam over a web UI
 icon: icon.png
 services:
   webcam-webui:
+    description: "Exposes your webcam over a web UI"
     start: bin/webcam-webui
 config: usr/bin/config.py
 


### PR DESCRIPTION
Use 'python3' instead of 'python3-project'. Add a service description to make click-review happy.