### PR TITLE
Don't filter out easy install's .pth and wrap config

### DIFF
--- a/integration-tests/units/jobs.pxu
+++ b/integration-tests/units/jobs.pxu
@@ -159,7 +159,7 @@ command:
     test -f ./snap/usr/bin/config.py
     test -f ./snap/usr/bin/python3
     test -f ./snap/meta/hooks/config
-    grep -q 'exec "usr/bin/config.py" $*' ./snap/meta/hooks/config
+    grep -q 'exec "$SNAP_APP_PATH/usr/bin/python3" "$SNAP_APP_PATH/usr/bin/config.py" $*' ./snap/meta/hooks/config
 flags: simple has-leftovers
 
 id: snapcraft/normal/simple-make

--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -85,15 +85,13 @@ def _write_readme_md(meta_dir, config_data):
 
 def _setup_config_hook(meta_dir, config):
     hooks_dir = os.path.join(meta_dir, 'hooks')
+    config_hook_path = os.path.join(hooks_dir, 'config')
 
     os.makedirs(hooks_dir)
 
     execparts = shlex.split(config)
-    args = execparts[1:] if len(execparts) > 1 else []
-
-    config_hook_path = os.path.join(hooks_dir, 'config')
-    _write_wrap_exe(execparts[0], config_hook_path, args=args,
-                    cwd='$SNAP_APP_PATH')
+    execwrap = _wrap_exe(execparts[0], args=execparts[1:])
+    os.rename(os.path.join(common.get_snapdir(), execwrap), config_hook_path)
 
 
 def _copy(meta_dir, relpath, new_relpath=None):
@@ -174,7 +172,7 @@ def _replace_cmd(execparts, cmd):
         return ' '.join([shlex.quote(x) for x in newparts])
 
 
-def _write_wrap_exe(wrapexec, wrappath, shebang=None, args=[], cwd=None):
+def _write_wrap_exe(wrapexec, wrappath, shebang=None, args=None, cwd=None):
     args = ' '.join(args) + ' $*' if args else '$*'
     cwd = 'cd {}'.format(cwd) if cwd else ''
 
@@ -202,7 +200,7 @@ def _write_wrap_exe(wrapexec, wrappath, shebang=None, args=[], cwd=None):
     os.chmod(wrappath, 0o755)
 
 
-def _wrap_exe(relexepath):
+def _wrap_exe(relexepath, args=None):
     snap_dir = common.get_snapdir()
     exepath = os.path.join(snap_dir, relexepath)
     wrappath = exepath + '.wrapper'
@@ -236,7 +234,7 @@ def _wrap_exe(relexepath):
             if exefile.read(2) == b'#!':
                 shebang = exefile.readline().strip().decode('utf-8')
 
-    _write_wrap_exe(wrapexec, wrappath, shebang=shebang)
+    _write_wrap_exe(wrapexec, wrappath, shebang=shebang, args=args)
 
     return os.path.relpath(wrappath, snap_dir)
 

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -148,7 +148,6 @@ class Python3Plugin(snapcraft.BasePlugin):
     def snap_fileset(self):
         fileset = super().snap_fileset()
         fileset.append('-usr/bin/pip*')
-        fileset.append('-usr/lib/python*/dist-packages/easy-install.pth')
         fileset.append('-usr/lib/python*/__pycache__/*.pyc')
         fileset.append('-usr/lib/python*/*/__pycache__/*.pyc')
         fileset.append('-usr/lib/python*/*/*/__pycache__/*.pyc')


### PR DESCRIPTION
The problem was two fold, on one side, the .pth file was missing for
easy install so pkg resources failed miserably to find the actual
defined script.

The other problem is that with the whole shebang rewrite story, the config
hook was neglected.

Fixes LP: #1519702

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>