### PR TITLE
Remove the `parts` arg from `init`

### DIFF
--- a/snapcraft/cmds.py
+++ b/snapcraft/cmds.py
@@ -51,16 +51,7 @@ def init(args):
     if os.path.exists('snapcraft.yaml'):
         logger.error('snapcraft.yaml already exists!')
         sys.exit(1)
-    yaml = _TEMPLATE_YAML
-    if args.part:
-        yaml += 'parts:\n'
-    for part_name in args.part:
-        part = lifecycle.load_plugin(part_name, part_name)
-        yaml += '    ' + part.name + ':\n'
-        for opt in part.config.get('options', []):
-            if part.config['options'][opt].get('required', False):
-                yaml += '        ' + opt + ':\n'
-    yaml = yaml.strip()
+    yaml = _TEMPLATE_YAML.strip()
     with open('snapcraft.yaml', mode='w+') as f:
         f.write(yaml)
     logger.info('Wrote the following as snapcraft.yaml.')

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -69,7 +69,6 @@ def main():
     # Command parsers
 
     parser = subparsers.add_parser('init', help='start a project')
-    parser.add_argument('part', nargs='*', help='part to add to new project')
     parser.set_defaults(func=snapcraft.cmds.init)
 
     parser = subparsers.add_parser('shell', help='enter staging environment')


### PR DESCRIPTION
This was never implemented correctly. We will fix this in 2.0

Fixes LP: #1516775

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>