### PR TITLE
Use testtools to run the examples tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # PPA for snappy.
   - sudo apt-add-repository -y ppa:snappy-dev/tools-proposed
   - sudo apt-get update -qq
-  - sudo apt-get install -qq build-essential dpkg-dev plainbox pyflakes python3-apt python3-coverage python3-fixtures python3-jsonschema python3-mccabe python3-pep8 python3-requests python3-testscenarios python3-yaml ubuntu-snappy-cli python3-lxml
+  - sudo apt-get install -qq build-essential dpkg-dev plainbox pyflakes python3-apt python3-coverage python3-fixtures python3-jsonschema python3-mccabe python3-pep8 python3-requests python3-testscenarios python3-testtools python3-yaml ubuntu-snappy-cli python3-lxml
 script:
   - ./runtests.sh $TEST_SUITE
 after_success:

--- a/examples_tests/__main__.py
+++ b/examples_tests/__main__.py
@@ -17,7 +17,8 @@
 import argparse
 import logging
 import sys
-import unittest
+
+from testtools import run
 
 from examples_tests import tests
 
@@ -49,7 +50,7 @@ def main():
     # Strip all the command line arguments, so unittest does not handle them
     # again.
     argv = [sys.argv[0]]
-    unittest.main('examples_tests.tests', verbosity=2, argv=argv)
+    run.TestProgram('examples_tests.tests', verbosity=2, argv=argv)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just by using testtools we improve a little the output of the tests in case of error:
ERROR: examples_tests.tests.TestSnapcraftExamples.test_example(webchat)

Requires #107.