### PR TITLE
Removing the `run` command

### DIFF
--- a/docs/snapcraft-usage.md
+++ b/docs/snapcraft-usage.md
@@ -35,8 +35,8 @@ prompts.
 After installing a summary of installed snaps will be presented, on vanilla
 x86-64 bit system it would look a lot like this:
 
-	Name          Date       Version      Developer 
-	ubuntu-core   2015-09-17 5            ubuntu    
+	Name          Date       Version      Developer
+	ubuntu-core   2015-09-17 5            ubuntu
 	downloader    2015-10-01 ICIEPfXHQOaC sideload  
 	generic-amd64 2015-10-01 1.4          canonical
 
@@ -44,15 +44,3 @@ Take notice of the sideload word in the downloader snap, this indicates that
 the snap did not come signed from the store, if an app is sideloaded, it
 also fakes the version to allow easy iteration without the need to change the
 metadata.
-
-## Using `snapcraft run`
-
-Instead of sideloading your app manually, you can use the following to
-speed up things:
-
-	$ snapcraft run
-
-Run this inside your project and an Ubuntu Core VM will be booted, your last
-successful .snap build will be uploaded to it and you will be connected to it
-via SSH automatically. Type `Ctrl-D` at end of testing your uploaded app and
-you are back to your previous working directory.

--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -19,7 +19,7 @@ parts:
         source: git://github.com/lool/snappy-mvn-demo.git
     tomcat:
         plugin: tar-content
-        source: http://mirrors.ircam.fr/pub/apache/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz
+        source: http://mirrors.ircam.fr/pub/apache/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz
     local-files:
         plugin: make
         source: .

--- a/integration-tests/units/jobs.pxu
+++ b/integration-tests/units/jobs.pxu
@@ -15,7 +15,7 @@ flags: simple has-leftovers
 id: snapcraft/normal/no-yaml-run
 command:
     set -x
-    OUTPUT=$(${SNAPCRAFT} run 2>&1)
+    OUTPUT=$(${SNAPCRAFT} pull 2>&1)
     test $? = 1 || exit 1
     echo $OUTPUT | grep "Could not find snapcraft\.yaml\."
 flags: simple has-leftovers

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -78,10 +78,6 @@ def main():
         help='optional command to run inside staging environment')
     parser.set_defaults(func=snapcraft.cmds.shell)
 
-    parser = subparsers.add_parser('run', help='run snap in kvm',
-                                   add_help=False)
-    parser.set_defaults(func=snapcraft.cmds.run)
-
     parser = subparsers.add_parser(
         'list-plugins',
         help='list the available plugins that handle different types '


### PR DESCRIPTION
In the new world order, this is to be replaced with `snappy try`.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>