### PR TITLE
cli: clean cmd migrated to docopts.

### DIFF
--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+snapcraft clean
+
+Remove content - download, build or install artifacts.
+
+Usage:
+  clean [options] [PART ...]
+
+Options:
+  -h --help             show this help message and exit.
+"""
+
+import os
+import logging
+import shutil
+import sys
+
+from docopt import docopt
+
+import snapcraft.yaml
+from snapcraft import common
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv=None):
+    argv = argv if argv else []
+    args = docopt(__doc__, argv=argv)
+
+    config = snapcraft.yaml.load_config()
+
+    part_names = {part.name for part in config.all_parts}
+    for part_name in args['PART']:
+        if part_name not in part_names:
+            logger.error('The part named {!r} is not defined in '
+                         '\'snapcraft.yaml\''.format(part_name))
+            sys.exit(1)
+
+    for part in config.all_parts:
+        if not args['PART'] or part.name in args['PART']:
+            part.clean()
+
+    # parts dir does not contain only generated code.
+    if (os.path.exists(common.get_partsdir()) and
+            not os.listdir(common.get_partsdir())):
+        os.rmdir(common.get_partsdir())
+
+    clean_stage = not args['PART'] or part_names == set(args['PART'])
+    if clean_stage and os.path.exists(common.get_stagedir()):
+        logger.info('Cleaning up staging area')
+        shutil.rmtree(common.get_stagedir())
+
+    if os.path.exists(common.get_snapdir()):
+        logger.info('Cleaning up snapping area')
+        shutil.rmtree(common.get_snapdir())

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -22,6 +22,8 @@ from unittest import mock
 
 import fixtures
 
+import snapcraft.yaml
+
 from snapcraft import (
     cmds,
     common,
@@ -213,182 +215,11 @@ parts:
 ''')
 
         with self.assertRaises(SystemExit) as raised:
-            cmds._load_config()
+            snapcraft.yaml.load_config()
 
         self.assertEqual(raised.exception.code, 1, 'Wrong exit code returned.')
         self.assertEqual(
             'Issue while loading plugin: unknown plugin: does-not-exist\n',
-            fake_logger.output)
-
-
-class CleanTestCase(tests.TestCase):
-
-    def setUp(self):
-        super().setUp()
-
-        patcher = mock.patch('shutil.rmtree')
-        self.mock_rmtree = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch('os.path.exists')
-        self.mock_exists = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch('os.listdir')
-        self.mock_listdir = patcher.start()
-        self.mock_listdir.return_value = []
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch('os.rmdir')
-        self.mock_rmdir = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.clean_calls = []
-
-        class FakePart:
-
-            def __init__(self, name, partdir):
-                self.name = name
-                self.partdir = partdir
-
-            def names(self):
-                return [self.name, ]
-
-            def clean(s):
-                self.clean_calls.append(s.name)
-
-        class FakeConfig:
-            all_parts = [
-                FakePart('part1', 'partdir1'),
-                FakePart('part2', 'partdir2'),
-                FakePart('part3', 'partdir3'),
-            ]
-
-        self.fake_config = FakeConfig()
-
-        patcher = mock.patch('snapcraft.cmds._load_config')
-        self.mock_load_config = patcher.start()
-        self.mock_load_config.return_value = self.fake_config
-        self.addCleanup(patcher.stop)
-
-    def test_clean_all(self):
-        class args:
-            parts = []
-        cmds.clean(args())
-
-        self.mock_exists.assert_has_calls([
-            mock.call(common.get_partsdir()),
-            mock.call().__bool__(),
-            mock.call(common.get_stagedir()),
-            mock.call().__bool__(),
-            mock.call(common.get_snapdir()),
-            mock.call().__bool__(),
-        ])
-
-        self.mock_rmtree.assert_has_calls([
-            mock.call(common.get_stagedir()),
-            mock.call(common.get_snapdir()),
-        ])
-
-        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
-        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
-
-    def test_clean_all_when_all_parts_specified(self):
-        class args:
-            parts = ['part1', 'part2', 'part3']
-        cmds.clean(args())
-
-        self.mock_exists.assert_has_calls([
-            mock.call(common.get_partsdir()),
-            mock.call().__bool__(),
-            mock.call(common.get_stagedir()),
-            mock.call().__bool__(),
-            mock.call(common.get_snapdir()),
-            mock.call().__bool__(),
-        ])
-
-        self.mock_rmtree.assert_has_calls([
-            mock.call(common.get_stagedir()),
-            mock.call(common.get_snapdir()),
-        ])
-
-        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
-        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
-
-    def test_partial_clean(self):
-        class args:
-            parts = ['part1']
-        cmds.clean(args())
-
-        self.mock_exists.assert_has_calls([
-            mock.call(common.get_partsdir()),
-            mock.call().__bool__(),
-            mock.call(common.get_snapdir()),
-            mock.call().__bool__(),
-        ])
-
-        self.mock_rmtree.assert_has_calls([
-            mock.call(common.get_snapdir()),
-        ])
-
-        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
-        self.assertEqual(self.clean_calls, ['part1'])
-
-    def test_everything_is_clean(self):
-        self.mock_exists.return_value = False
-        self.mock_listdir.side_effect = FileNotFoundError()
-
-        class args:
-            parts = []
-        cmds.clean(args())
-
-        self.mock_exists.assert_has_calls([
-            mock.call(common.get_partsdir()),
-            mock.call(common.get_stagedir()),
-            mock.call(common.get_snapdir()),
-        ])
-
-        self.assertFalse(self.mock_rmdir.called)
-        self.assertFalse(self.mock_rmtree.called)
-        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
-
-    def test_no_parts_defined(self):
-        self.fake_config.all_parts = []
-
-        self.mock_load_config.return_value = self.fake_config
-
-        class args:
-            parts = []
-
-        cmds.clean(args())
-
-        self.mock_exists.assert_has_calls([
-            mock.call(common.get_stagedir()),
-            mock.call().__bool__(),
-            mock.call(common.get_snapdir()),
-            mock.call().__bool__(),
-        ])
-
-        self.mock_rmtree.assert_has_calls([
-            mock.call(common.get_stagedir()),
-            mock.call(common.get_snapdir()),
-        ])
-
-        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
-
-    def test_part_to_remove_not_defined_exits_with_error(self):
-        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
-        self.useFixture(fake_logger)
-
-        class args:
-            parts = ['does-not-exist']
-
-        with self.assertRaises(SystemExit) as raised:
-            cmds.clean(args())
-        self.assertEqual(raised.exception.code, 1, 'Wrong exit code returned.')
-        self.assertEqual(
-            "The part named 'does-not-exist' is not defined in "
-            "'snapcraft.yaml'\n",
             fake_logger.output)
 
 

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -1,0 +1,181 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from unittest import mock
+
+import fixtures
+
+from snapcraft import common
+from snapcraft import tests
+from snapcraft.commands import clean
+
+
+class CleanCommandTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch('shutil.rmtree')
+        self.mock_rmtree = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('os.path.exists')
+        self.mock_exists = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('os.listdir')
+        self.mock_listdir = patcher.start()
+        self.mock_listdir.return_value = []
+        self.addCleanup(patcher.stop)
+
+        patcher = mock.patch('os.rmdir')
+        self.mock_rmdir = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.clean_calls = []
+
+        class FakePart:
+
+            def __init__(self, name, partdir):
+                self.name = name
+                self.partdir = partdir
+
+            def names(self):
+                return [self.name, ]
+
+            def clean(s):
+                self.clean_calls.append(s.name)
+
+        class FakeConfig:
+            all_parts = [
+                FakePart('part1', 'partdir1'),
+                FakePart('part2', 'partdir2'),
+                FakePart('part3', 'partdir3'),
+            ]
+
+        self.fake_config = FakeConfig()
+
+        patcher = mock.patch('snapcraft.yaml.load_config')
+        self.mock_load_config = patcher.start()
+        self.mock_load_config.return_value = self.fake_config
+        self.addCleanup(patcher.stop)
+
+    def test_clean_all(self):
+        clean.main()
+
+        self.mock_exists.assert_has_calls([
+            mock.call(common.get_partsdir()),
+            mock.call().__bool__(),
+            mock.call(common.get_stagedir()),
+            mock.call().__bool__(),
+            mock.call(common.get_snapdir()),
+            mock.call().__bool__(),
+        ])
+
+        self.mock_rmtree.assert_has_calls([
+            mock.call(common.get_stagedir()),
+            mock.call(common.get_snapdir()),
+        ])
+
+        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
+        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
+
+    def test_clean_all_when_all_parts_specified(self):
+        clean.main(['part1', 'part2', 'part3'])
+
+        self.mock_exists.assert_has_calls([
+            mock.call(common.get_partsdir()),
+            mock.call().__bool__(),
+            mock.call(common.get_stagedir()),
+            mock.call().__bool__(),
+            mock.call(common.get_snapdir()),
+            mock.call().__bool__(),
+        ])
+
+        self.mock_rmtree.assert_has_calls([
+            mock.call(common.get_stagedir()),
+            mock.call(common.get_snapdir()),
+        ])
+
+        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
+        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
+
+    def test_partial_clean(self):
+        clean.main(['part1', ])
+
+        self.mock_exists.assert_has_calls([
+            mock.call(common.get_partsdir()),
+            mock.call().__bool__(),
+            mock.call(common.get_snapdir()),
+            mock.call().__bool__(),
+        ])
+
+        self.mock_rmtree.assert_has_calls([
+            mock.call(common.get_snapdir()),
+        ])
+
+        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
+        self.assertEqual(self.clean_calls, ['part1'])
+
+    def test_everything_is_clean(self):
+        self.mock_exists.return_value = False
+        self.mock_listdir.side_effect = FileNotFoundError()
+
+        clean.main()
+
+        self.mock_exists.assert_has_calls([
+            mock.call(common.get_partsdir()),
+            mock.call(common.get_stagedir()),
+            mock.call(common.get_snapdir()),
+        ])
+
+        self.assertFalse(self.mock_rmdir.called)
+        self.assertFalse(self.mock_rmtree.called)
+        self.assertEqual(self.clean_calls, ['part1', 'part2', 'part3'])
+
+    def test_no_parts_defined(self):
+        self.fake_config.all_parts = []
+
+        self.mock_load_config.return_value = self.fake_config
+
+        clean.main()
+
+        self.mock_exists.assert_has_calls([
+            mock.call(common.get_stagedir()),
+            mock.call().__bool__(),
+            mock.call(common.get_snapdir()),
+            mock.call().__bool__(),
+        ])
+
+        self.mock_rmtree.assert_has_calls([
+            mock.call(common.get_stagedir()),
+            mock.call(common.get_snapdir()),
+        ])
+
+        self.mock_rmdir.assert_called_once_with(common.get_partsdir())
+
+    def test_part_to_remove_not_defined_exits_with_error(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        with self.assertRaises(SystemExit) as raised:
+            clean.main(['does-not-exist'])
+        self.assertEqual(raised.exception.code, 1, 'Wrong exit code returned.')
+        self.assertEqual(
+            "The part named 'does-not-exist' is not defined in "
+            "'snapcraft.yaml'\n",
+            fake_logger.output)


### PR DESCRIPTION
This also involved moving `load_config` to the `yaml` module.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>