### PR TITLE
clean cmd: migrate to use new lifecycle attribs

### DIFF
--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -30,7 +30,6 @@ Options:
 import os
 import logging
 import shutil
-import sys
 
 from docopt import docopt
 
@@ -46,12 +45,8 @@ def main(argv=None):
 
     config = snapcraft.yaml.load_config()
 
-    part_names = {part.name for part in config.all_parts}
-    for part_name in args['PART']:
-        if part_name not in part_names:
-            logger.error('The part named {!r} is not defined in '
-                         '\'snapcraft.yaml\''.format(part_name))
-            sys.exit(1)
+    if args['PART']:
+        config.validate_parts(args['PART'])
 
     for part in config.all_parts:
         if not args['PART'] or part.name in args['PART']:
@@ -62,7 +57,9 @@ def main(argv=None):
             not os.listdir(common.get_partsdir())):
         os.rmdir(common.get_partsdir())
 
-    clean_stage = not args['PART'] or part_names == set(args['PART'])
+    parts_match = set(config.part_names) == set(args['PART'])
+    # Only clean stage if all the parts were cleaned up.
+    clean_stage = not args['PART'] or parts_match
     if clean_stage and os.path.exists(common.get_stagedir()):
         logger.info('Cleaning up staging area')
         shutil.rmtree(common.get_stagedir())

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import io
 import logging
 import os
 import tempfile
@@ -29,12 +28,6 @@ from snapcraft import (
     lifecycle,
     tests
 )
-
-
-class _IO(io.StringIO):
-
-    def fileno(self):
-        return 1
 
 
 class TestCommands(tests.TestCase):

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -29,9 +29,8 @@ import snapcraft.lifecycle
 import snapcraft.tests
 
 
-def get_test_plugin(name='copy', part_name='mock-part', properties=None):
-    if properties is None:
-        properties = {'files': {'1': '1'}}
+def get_test_plugin(name='copy', part_name='mock-part'):
+    properties = {'files': {'1': '1'}}
     return snapcraft.lifecycle.PluginHandler(name, part_name, properties)
 
 

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -94,6 +94,10 @@ class PluginNotDefinedError(Exception):
 
 class Config:
 
+    @property
+    def part_names(self):
+        return self._part_names
+
     def __init__(self):
         self.build_tools = []
         self.all_parts = []


### PR DESCRIPTION
This also migrates clean to use real elements instead of
over mocking.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>