### PR TITLE
Catkin plugin: Add support for ROS tools.

### DIFF
--- a/examples/ros/snapcraft.yaml
+++ b/examples/ros/snapcraft.yaml
@@ -7,9 +7,9 @@ description: A really small ROS example
 
 binaries:
   listener:
-    exec: opt/ros/indigo/beginner_tutorials/lib/beginner_tutorials/listener
+    exec: rosrun beginner_tutorials listener
   talker:
-    exec: opt/ros/indigo/beginner_tutorials/lib/beginner_tutorials/talker
+    exec: rosrun beginner_tutorials talker
 
 services:
   rosmaster:

--- a/examples/ros/src/beginner_tutorials/CMakeLists.txt
+++ b/examples/ros/src/beginner_tutorials/CMakeLists.txt
@@ -1,4 +1,3 @@
-# %Tag(FULLTEXT)%
 cmake_minimum_required(VERSION 2.8.3)
 project(beginner_tutorials)
 
@@ -25,7 +24,6 @@ add_executable(listener src/listener.cpp)
 target_link_libraries(listener ${catkin_LIBRARIES})
 
 ## Build service client and server
-# %Tag(SRVCLIENT)%
 add_executable(add_two_ints_server src/add_two_ints_server.cpp)
 target_link_libraries(add_two_ints_server ${catkin_LIBRARIES})
 add_dependencies(add_two_ints_server beginner_tutorials_gencpp)
@@ -34,6 +32,9 @@ add_executable(add_two_ints_client src/add_two_ints_client.cpp)
 target_link_libraries(add_two_ints_client ${catkin_LIBRARIES})
 add_dependencies(add_two_ints_client beginner_tutorials_gencpp)
 
-# %EndTag(SRVCLIENT)%
-
-# %EndTag(FULLTEXT)%
+## Mark executables for installation
+install(TARGETS talker listener add_two_ints_server add_two_ints_client
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
The current Catkin plugin distributes only the built version of a ROS package that would typically go into the devel workspace, but that version doesn't include non-source, non-binary files, such as .launch files. This PR changes the plugin to actually install ROS packages, thereby including any non-source, non-binary files specified by the developer.

This PR also updates the wrapper environment to correctly setup the ROS environment, which allows for the use of typical ROS tools within the snapcraft.yaml, such as roslaunch, rosrun, etc., and updates the ROS examples to make use of them.

Finally, this PR also increases the test coverage of the Catkin plugin twofold.