### PR TITLE
Making the icon optional

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -160,5 +160,4 @@ required:
   - version
   - summary
   - description
-  - icon
   - parts

--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -31,12 +31,12 @@ logger = logging.getLogger(__name__)
 _MANDATORY_PACKAGE_KEYS = [
     'name',
     'version',
-    'icon',
 ]
 
 _OPTIONAL_PACKAGE_KEYS = [
     'frameworks',
     'type',
+    'icon',
 ]
 
 
@@ -57,7 +57,8 @@ def create(config_data):
     meta_dir = os.path.join(common.get_snapdir(), 'meta')
     os.makedirs(meta_dir, exist_ok=True)
 
-    config_data['icon'] = _copy(meta_dir, config_data['icon'])
+    if 'icon' in config_data:
+        config_data['icon'] = _copy(meta_dir, config_data['icon'])
 
     if 'framework-policy' in config_data:
         _copy(meta_dir, config_data['framework-policy'], 'framework-policy')

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -361,7 +361,6 @@ class TestValidation(TestCase):
             'version': '1.0-snapcraft1~ppa1',
             'summary': 'my summary less that 79 chars',
             'description': 'description which can be pretty long',
-            'icon': 'my-icon.png',
             'parts': {
                 'part1': {
                     'plugin': 'project',
@@ -526,15 +525,10 @@ class TestValidation(TestCase):
                             'installation path')
         self.assertEqual(raised.exception.message, expected_message)
 
-    def test_icon_missing(self):
+    def test_icon_missing_is_valid_yaml(self):
         self.mock_path_exists.return_value = False
 
-        with self.assertRaises(snapcraft.yaml.SnapcraftSchemaError) as raised:
-            snapcraft.yaml._validate_snapcraft_yaml(self.data)
-
-        expected_message = '\'my-icon.png\' is not a \'icon-path\''
-        self.assertEqual(raised.exception.message, expected_message,
-                         msg=self.data)
+        snapcraft.yaml._validate_snapcraft_yaml(self.data)
 
     def test_invalid_part_name_plugin_raises_exception(self):
         self.data['parts']['plugins'] = {'type': 'go'}


### PR DESCRIPTION
The store should provide an icon if it is missing.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>