### PR TITLE
use archive.apache.org URL to ensure we refer to a stable URL that do…

### DIFF
--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -19,7 +19,7 @@ parts:
         source: git://github.com/lool/snappy-mvn-demo.git
     tomcat:
         plugin: tar-content
-        source: http://mirrors.ircam.fr/pub/apache/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz
+        source: https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz
     local-files:
         plugin: make
         source: .


### PR DESCRIPTION
…es not disappear on latest release