### PR TITLE
Resolve xml2-config FIXME in Catkin plugin

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -243,10 +243,6 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
         self._find_package_deps()
         self._build_packages_deps()
 
-        # FIXME: Removing this here since it'll clash with the one from
-        # roscore. Remove this line once the roscore plugin is gone.
-        os.remove(os.path.join(self.installdir, 'usr/bin/xml2-config'))
-
         # Fix the shebang in _setup_util.py to be portable
         with open('{}/opt/ros/{}/_setup_util.py'.format(
                   self.installdir, self.options.rosversion), 'r+') as f:

--- a/snapcraft/plugins/roscore.py
+++ b/snapcraft/plugins/roscore.py
@@ -73,6 +73,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             os.path.join('bin', self.name + '-rosmaster-service'),
             os.path.join(rospath, 'bin', '*'),
             os.path.join(rospath, 'lib', '*'),
+            '-' + os.path.join('usr', 'bin', 'xml2-config'),
             '-' + os.path.join(rospath, 'share', '*', 'cmake', '*'),
             '-' + os.path.join(rospath, 'include'),
             '-' + os.path.join(rospath, '.catkin'),


### PR DESCRIPTION
This simply moves the hack into the roscore plugin, which already has more of them anyway.