### PR TITLE
Updated the autopkgtests.

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,5 +1,4 @@
-Tests: runtests
-       runexamples
+Tests: integrationtests examplestests
 Restrictions: allow-stderr, isolation-container, rw-build-tree
 Depends: @,
          build-essential,

--- a/debian/tests/examplestests
+++ b/debian/tests/examplestests
@@ -1,0 +1,2 @@
+#!/bin/sh
+./runtests.sh examples --skip-install

--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -1,0 +1,2 @@
+#!/bin/sh
+./runtests.sh plainbox

--- a/debian/tests/runexamples
+++ b/debian/tests/runexamples
@@ -1,2 +1,0 @@
-#!/bin/sh
-./runtests.sh plainbox examples

--- a/debian/tests/runtests
+++ b/debian/tests/runtests
@@ -1,2 +1,0 @@
-#!/bin/sh
-./runtests.sh


### PR DESCRIPTION
On autopkgtests, run the integration tests, build the examples but do not install them, do not run the unittests.

The unittests are run when the package is built, so no need to run them again during package update.
The examples install tests will run only daily, and on PRs.