### PR TITLE
Python{2,3} plugins: Make site-packages link relative.

### DIFF
--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -97,11 +97,11 @@ class Python2Plugin(snapcraft.BasePlugin):
         site_packages_dir = os.path.join(
             prefix, 'lib', self.python_version, 'site-packages')
 
+        # If site-packages doesn't exist, make sure it points to the
+        # dist-packages in the same directory (this is a relative link so that
+        # it's still valid when the .snap is installed).
         if not os.path.exists(site_packages_dir):
-            os.symlink(
-                os.path.join(prefix, 'lib', self.python_version,
-                             'dist-packages'),
-                site_packages_dir)
+            os.symlink('dist-packages', site_packages_dir)
 
         self.run(['python2', easy_install, '--prefix', prefix, 'pip'])
 

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -97,10 +97,13 @@ class Python3Plugin(snapcraft.BasePlugin):
         site_packages_dir = os.path.join(
             prefix, 'lib', self.python_version, 'site-packages')
 
+        # If site-packages doesn't exist, make sure it points to the
+        # python3 dist-packages (this is a relative link so that it's still
+        # valid when the .snap is installed). Note that all python3 versions
+        # share the same dist-packages (e.g. in python3, not python3.4).
         if not os.path.exists(site_packages_dir):
-            os.symlink(
-                os.path.join(prefix, 'lib', 'python3', 'dist-packages'),
-                site_packages_dir)
+            os.symlink(os.path.join('..', 'python3', 'dist-packages'),
+                       site_packages_dir)
 
         self.run(['python3', easy_install, '--prefix', prefix, 'pip'])
 

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -1,0 +1,55 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from unittest import mock
+
+from snapcraft import tests
+from snapcraft.plugins import python2
+
+
+class Python2PluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            requirements = ''
+            python_packages = []
+
+        self.options = Options()
+
+    @mock.patch.object(python2.Python2Plugin, 'run')
+    @mock.patch.object(python2.Python2Plugin, 'run_output',
+                       return_value='python2.7')
+    def test_pip_relative_site_packages_symlink(self, run_output_mock,
+                                                run_mock):
+        plugin = python2.Python2Plugin('test-part', self.options)
+        os.makedirs(plugin.sourcedir)
+        os.makedirs(os.path.join(plugin.installdir, 'usr', 'lib', 'python2.7',
+                                 'dist-packages'))
+
+        open(os.path.join(plugin.sourcedir, 'setup.py'), 'w').close()
+
+        plugin._pip()
+
+        link = os.readlink(os.path.join(plugin.installdir, 'usr', 'lib',
+                                        'python2.7', 'site-packages'))
+        self.assertEqual(link, 'dist-packages',
+                         'Expected site-packages to be a relative link to '
+                         '"dist-packages", but it was a link to "{}"'
+                         .format(link))

--- a/snapcraft/tests/test_plugin_python3.py
+++ b/snapcraft/tests/test_plugin_python3.py
@@ -1,0 +1,57 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from unittest import mock
+
+from snapcraft import tests
+from snapcraft.plugins import python3
+
+
+class Python3PluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            requirements = ''
+            python_packages = []
+
+        self.options = Options()
+
+    @mock.patch.object(python3.Python3Plugin, 'run')
+    @mock.patch.object(python3.Python3Plugin, 'run_output',
+                       return_value='python3.4')
+    def test_pip_relative_site_packages_symlink(self, run_output_mock,
+                                                run_mock):
+        plugin = python3.Python3Plugin('test-part', self.options)
+        os.makedirs(plugin.sourcedir)
+        os.makedirs(os.path.join(plugin.installdir, 'usr', 'lib', 'python3.4'))
+        os.makedirs(os.path.join(plugin.installdir, 'usr', 'lib', 'python3',
+                                 'dist-packages'))
+
+        open(os.path.join(plugin.sourcedir, 'setup.py'), 'w').close()
+
+        plugin._pip()
+
+        link = os.readlink(os.path.join(plugin.installdir, 'usr', 'lib',
+                                        'python3.4', 'site-packages'))
+        expected = os.path.join('..', 'python3', 'dist-packages')
+        self.assertEqual(link, expected,
+                         'Expected site-packages to be a relative link to '
+                         '"{}", but it was a link to "{}"'.format(expected,
+                                                                  link))


### PR DESCRIPTION
Currently the Python2 and Python3 plugins create a `<install>/usr/lib/<pythonversion>/site-packages` symlink to `<install>/usr/lib/<pythonversion>/dist-packages`, but that absolute link doesn't exist when the .snap is installed. This commit makes the link relative instead of absolute so the link stays valid.

This may be worth cherry-picking to 1.x.

Fixes LP: [#1523384](https://bugs.launchpad.net/snapcraft/+bug/1523384)