### PR TITLE
Cherry-pick for 1.x: Wrapping exe should not be over match to replace

### DIFF
--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -178,7 +178,8 @@ def _write_wrap_exe(wrapexec, wrappath, shebang=None, args=None, cwd=None):
 
     snap_dir = common.get_snapdir()
     assembled_env = common.assemble_env().replace(snap_dir, '$SNAP_APP_PATH')
-    replace_path = r'{}/.*/install'.format(common.get_partsdir())
+    replace_path = r'{}/[a-z0-9][a-z0-9+-]*/install'.format(
+        common.get_partsdir())
     assembled_env = re.sub(replace_path, '$SNAP_APP_PATH', assembled_env)
     executable = '"{}"'.format(wrapexec)
     if shebang is not None:

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -344,7 +344,12 @@ class Create(tests.TestCase):
 # TODO this needs more tests.
 class WrapExeTestCase(tests.TestCase):
 
-    def test_wrap_exe_must_write_wrapper(self):
+    @patch('snapcraft.common.assemble_env')
+    def test_wrap_exe_must_write_wrapper(self, mock_assemble_env):
+        mock_assemble_env.return_value = """\
+PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
+""".format(common.get_partsdir())
+
         snapdir = common.get_snapdir()
         os.mkdir(snapdir)
 
@@ -356,6 +361,7 @@ class WrapExeTestCase(tests.TestCase):
         wrapper_path = os.path.join(snapdir, relative_wrapper_path)
 
         expected = ('#!/bin/sh\n'
+                    'PATH=$SNAP_APP_PATH/usr/bin:$SNAP_APP_PATH/bin\n'
                     '\n\n'
                     'exec "$SNAP_APP_PATH/test_relexepath" $*\n')
         with open(wrapper_path) as wrapper_file:


### PR DESCRIPTION
This is a cherry-pick of #162 to 1.x