### PR TITLE
Cherry-pick for 1.x: use archive.apache.org URL to ensure we refer to a stable URL that do…

### DIFF
--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -19,7 +19,7 @@ parts:
         source: git://github.com/lool/snappy-mvn-demo.git
     tomcat:
         plugin: tar-content
-        source: http://mirrors.ircam.fr/pub/apache/tomcat/tomcat-8/v8.0.28/bin/apache-tomcat-8.0.28.tar.gz
+        source: https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.29/bin/apache-tomcat-8.0.29.tar.gz
     local-files:
         plugin: make
         source: .


### PR DESCRIPTION
This is a cherry-pick of #156 for 1.x

Conflicts:
	examples/tomcat-maven-webapp/snapcraft.yaml

Conflict occured because the master was using v8.0.29 already, the URL just needed to change, but 1.x was using v8.0.28. Fixed by simply using v8.0.29 (with the new URL).