### PR TITLE
Catkin plugin: Refactor build.

### DIFF
--- a/docs/ros-snap.md
+++ b/docs/ros-snap.md
@@ -352,7 +352,7 @@ out:
 And you should see the talker and listener communicating like before. As usual,
 ctrl+c will stop it. Note also that, since ROS is running in a confined
 environment, its log isn't in `$HOME/.ros` as usual, but in
-`$HOME/apps/ros-talker-and-listener.sideload/1.0/.ros`.
+`$HOME/apps/ros-talker-and-listener.sideload/1.0/ros`.
 
 [1]: http://www.ros.org/
 [2]: get-started.md


### PR DESCRIPTION
This PR contains a number of small refactors:

- Change `env()` to only contain variables for run-time, and document each of them.
- Only obtain dependencies upon `pull()`-- for `build()` they should just be ready to go.
- Extract dependency resolution into a standalone function that can be tested in isolation.
- Change `build()` to be less clever and more simple/verbose/robust.
- Add `source-space` keyword to get rid of custom `build()`.
- Get unit testing coverage of the Catkin plugin to 100%.