### PR TITLE
Testing of success of 'type' part deletion in wiki.py

### DIFF
--- a/snapcraft/tests/test_wiki.py
+++ b/snapcraft/tests/test_wiki.py
@@ -51,11 +51,13 @@ class TestYaml(TestCase):
         self.assertEqual(self.w.get_part('part-in-wiki'), {
             'plugin': 'go', 'source': 'http://somesource'})
         self.assertEqual(self.w.get_part('part-not-in-wiki'), None)
-    
+
     def test_get_part_type(self):
-        self.assertNotEqual(self.w.get_part('part-in-wiki'), {'plugin': 'go', 'source': 'http://somesource', 'source-type': 'type'})
+        result = self.w.get_part('part-in-wiki')
+        not_expected = {'plugin': 'go', 'source': '.', 'source-type': 'type'}
+        self.assertNotEqual(result, not_expected)
         self.assertEqual(self.w.get_part('part-not-in-wiki'), None)
-    
+
     def test_compose_part_with_properties_from_the_wiki(self):
         properties = self.w.compose(
             'part-in-wiki', {'source': '.', 'another': 'different'})

--- a/snapcraft/tests/test_wiki.py
+++ b/snapcraft/tests/test_wiki.py
@@ -53,8 +53,9 @@ class TestYaml(TestCase):
         self.assertEqual(self.w.get_part('part-not-in-wiki'), None)
     
     def test_get_part_type(self):
-        self.assertNotEqual(self.w.get_part('part-in-wiki'), {'source-type': 'type'})
-
+        self.assertNotEqual(self.w.get_part('part-in-wiki'), {'plugin': 'go', 'source': 'http://somesource', 'source-type': 'type'})
+        self.assertEqual(self.w.get_part('part-not-in-wiki'), None)
+    
     def test_compose_part_with_properties_from_the_wiki(self):
         properties = self.w.compose(
             'part-in-wiki', {'source': '.', 'another': 'different'})

--- a/snapcraft/tests/test_wiki.py
+++ b/snapcraft/tests/test_wiki.py
@@ -51,6 +51,9 @@ class TestYaml(TestCase):
         self.assertEqual(self.w.get_part('part-in-wiki'), {
             'plugin': 'go', 'source': 'http://somesource'})
         self.assertEqual(self.w.get_part('part-not-in-wiki'), None)
+    
+    def test_get_part_type(self):
+        self.assertNotEqual(self.w.get_part('part-in-wiki'), {'source-type': 'type'})
 
     def test_compose_part_with_properties_from_the_wiki(self):
         properties = self.w.compose(


### PR DESCRIPTION
There is a line(#50) that is not tested by the test-code. In the added test we try to be sure that 'type' part of the 'part-in-wiki' was deleted successfully. To do so, we check that the result of get_part() function is not equal to the result where 'source-type' part is present. In the case of part-not-in-wiki, we should check also that source-type isn't there so result must be 'None'