### PR TITLE
node.js plugin: add node-folder property (default: '.')

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -28,6 +28,9 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - node-packages:
       (list)
       A list of dependencies to fetch using npm.
+    - node-folder:
+      (string)
+      A relative path to the folder containing the package.json to use with npm install
 """
 
 import logging
@@ -65,6 +68,11 @@ class NodePlugin(snapcraft.BasePlugin):
             'default': [],
         }
 
+        schema['properties']['node-folder'] = {
+            'type': 'string',
+	    'default': '.',
+        }
+
         if 'required' in schema:
             del schema['required']
 
@@ -85,8 +93,8 @@ class NodePlugin(snapcraft.BasePlugin):
         self._nodejs_tar.provision(self.installdir)
         for pkg in self.options.node_packages:
             self.run(['npm', 'install', '-g', pkg])
-        if os.path.exists(os.path.join(self.builddir, 'package.json')):
-            self.run(['npm', 'install', '-g'])
+        if os.path.exists(os.path.join(self.builddir, self.options.node_folder, 'package.json')):
+            self.run(['npm', 'install', '-g', os.path.join(self.builddir, self.options.node_folder)])
 
 
 def _get_nodejs_base():


### PR DESCRIPTION
This adds support for building snap parts from sources that dont have their
package.json in the top level directory (such as https://github.com/asac/etherpad-lite).