### PR TITLE
node.js plugin: add node-folder property (default: '.')

### DIFF
--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -28,6 +28,10 @@ Additionally, this plugin uses the following plugin-specific keywords:
     - node-packages:
       (list)
       A list of dependencies to fetch using npm.
+    - node-folder:
+      (string)
+      A relative path to the folder containing the package.json to use with
+      npm install
 """
 
 import logging
@@ -65,6 +69,11 @@ class NodePlugin(snapcraft.BasePlugin):
             'default': [],
         }
 
+        schema['properties']['node-folder'] = {
+            'type': 'string',
+            'default': '.',
+        }
+
         if 'required' in schema:
             del schema['required']
 
@@ -85,8 +94,11 @@ class NodePlugin(snapcraft.BasePlugin):
         self._nodejs_tar.provision(self.installdir)
         for pkg in self.options.node_packages:
             self.run(['npm', 'install', '-g', pkg])
-        if os.path.exists(os.path.join(self.builddir, 'package.json')):
-            self.run(['npm', 'install', '-g'])
+        if os.path.exists(os.path.join(self.builddir,
+                                       self.options.node_folder,
+                                       'package.json')):
+            self.run(['npm', 'install', '-g',
+                     os.path.join(self.builddir, self.options.node_folder)])
 
 
 def _get_nodejs_base():

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -44,6 +44,7 @@ class NodePluginTestCase(tests.TestCase):
         class Options:
             source = '.'
             node_packages = []
+            node_folder = '.'
 
         plugin = nodejs.NodePlugin('test-part', Options())
 
@@ -58,10 +59,34 @@ class NodePluginTestCase(tests.TestCase):
                 path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
             mock.call().pull()])
 
+    def test_build_local_sources_and_node_folder(self):
+        class Options:
+            source = '.'
+            node_packages = []
+            node_folder = 'subdir'
+
+        plugin = nodejs.NodePlugin('test-part', Options())
+
+        os.makedirs(plugin.sourcedir)
+        os.makedirs(os.path.join(plugin.sourcedir, plugin.options.node_folder))
+        open(os.path.join(plugin.sourcedir, plugin.options.node_folder,
+                          'package.json'), 'w').close()
+
+        plugin.build()
+
+        self.run_mock.assert_has_calls([
+            mock.call(['npm', 'install', '-g'], cwd=plugin.builddir)])
+        self.tar_mock.assert_has_calls([
+            mock.call(
+                nodejs._get_nodejs_release(),
+                path.join(os.path.abspath('.'), 'parts', 'test-part', 'npm')),
+            mock.call().provision(plugin.installdir)])
+
     def test_build_local_sources(self):
         class Options:
             source = '.'
             node_packages = []
+            node_folder = '.'
 
         plugin = nodejs.NodePlugin('test-part', Options())
 
@@ -82,6 +107,7 @@ class NodePluginTestCase(tests.TestCase):
         class Options:
             source = None
             node_packages = ['my-pkg']
+            node_folder = '.'
 
         plugin = nodejs.NodePlugin('test-part', Options())
 
@@ -107,6 +133,7 @@ class NodePluginTestCase(tests.TestCase):
         class Options:
             source = None
             node_packages = []
+            node_folder = '.'
 
         with self.assertRaises(EnvironmentError) as raised:
             nodejs.NodePlugin('test-part', Options())


### PR DESCRIPTION
This adds support for building snap parts from sources that dont have their
package.json in the top level directory (such as https://github.com/asac/etherpad-lite).