### PR TITLE
Add support for mesa libraries.

### DIFF
--- a/examples/opencv/snapcraft.yaml
+++ b/examples/opencv/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: opencv-example
+version: 1.0
+summary: Use OpenCV and OpenGL
+description: A simple OpenCV example
+
+binaries:
+  example:
+    exec: bin/example
+
+parts:
+  example:
+    plugin: cmake
+    source: src
+    stage-packages: [libopencv-dev]

--- a/examples/opencv/src/CMakeLists.txt
+++ b/examples/opencv/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.6)
+project(example)
+
+find_package(OpenCV REQUIRED)
+
+add_executable(example main.cpp)
+
+target_link_libraries(example ${OpenCV_LIBS})
+
+install(TARGETS example RUNTIME DESTINATION bin)

--- a/examples/opencv/src/main.cpp
+++ b/examples/opencv/src/main.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include <opencv2/core/core.hpp>
+
+int main()
+{
+    cv::Mat matrix(2, 2, CV_8UC1);
+
+    matrix.at<uint8_t>(cv::Point(0, 0)) = 1;
+    matrix.at<uint8_t>(cv::Point(0, 1)) = 2;
+    matrix.at<uint8_t>(cv::Point(1, 0)) = 3;
+    matrix.at<uint8_t>(cv::Point(1, 1)) = 4;
+
+    std::cout << matrix << std::endl;
+}

--- a/examples_tests/tests.py
+++ b/examples_tests/tests.py
@@ -125,6 +125,11 @@ class TestSnapcraftExamples(testscenarios.TestWithScenarios):
                  'custom libpipeline called\n'
                  'include\n')],
             }),
+        ('opencv', {
+            'dir': 'opencv',
+            'name': 'opencv-example',
+            'version': '1.0',
+            }),
         ('py2-project', {
             'dir': 'py2-project',
             'name': 'spongeshaker',

--- a/snapcraft/libraries.py
+++ b/snapcraft/libraries.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import glob
+
+
+def determine_ld_library_path(root):
+    # If more ld.so.conf files need to be supported, add them here.
+    ld_config_globs = {
+        '{}/usr/lib/*/mesa*/ld.so.conf'.format(root)
+    }
+
+    ld_library_paths = []
+    for this_glob in ld_config_globs:
+        for ld_conf_file in glob.glob(this_glob):
+            ld_library_paths.extend(_extract_ld_library_paths(ld_conf_file))
+
+    return [root + path for path in ld_library_paths]
+
+
+def _extract_ld_library_paths(ld_conf_file):
+    # From the ldconfig manpage, paths can be colon-, space-, tab-, newline-,
+    # or comma-separated.
+    path_delimiters = re.compile(r'[:\s,]')
+    comments = re.compile(r'#.*$')
+
+    paths = []
+    with open(ld_conf_file, 'r') as f:
+        for line in f:
+            # Remove comments from line
+            line = comments.sub('', line).strip()
+
+            if line:
+                paths.extend(path_delimiters.split(line))
+
+    return paths

--- a/snapcraft/tests/test_libraries.py
+++ b/snapcraft/tests/test_libraries.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tempfile
+
+from snapcraft import (
+    libraries,
+    tests,
+)
+
+
+class TestLdLibraryPathParser(tests.TestCase):
+
+    def _write_conf_file(self, contents):
+        tmp = tempfile.NamedTemporaryFile(delete=False, mode='w')
+        self.addCleanup(os.remove, tmp.name)
+
+        tmp.write(contents)
+        tmp.close()
+
+        return tmp.name
+
+    def test_extract_ld_library_paths(self):
+        file_path = self._write_conf_file("""# This is a comment
+/foo/bar
+/colon:/separated,/comma\t/tab /space # This is another comment
+/baz""")
+
+        self.assertEqual(['/foo/bar', '/colon', '/separated', '/comma',
+                          '/tab', '/space', '/baz'],
+                         libraries._extract_ld_library_paths(file_path))

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -26,6 +26,7 @@ import yaml
 
 from snapcraft import (
     common,
+    libraries,
     pluginhandler,
     wiki,
 )
@@ -205,6 +206,8 @@ class Config:
             '{0}/usr/bin',
             '$PATH'
         ]).format(root) + '"')
+
+        # Add the default LD_LIBRARY_PATH
         env.append('LD_LIBRARY_PATH="' + ':'.join([
             '{0}/lib',
             '{0}/usr/lib',
@@ -212,6 +215,13 @@ class Config:
             '{0}/usr/lib/{1}',
             '$LD_LIBRARY_PATH'
         ]).format(root, common.get_arch_triplet()) + '"')
+
+        # Add more specific LD_LIBRARY_PATH if necessary
+        ld_library_paths = libraries.determine_ld_library_path(root)
+        if ld_library_paths:
+            env.append('LD_LIBRARY_PATH="' + ':'.join(ld_library_paths) +
+                       ':$LD_LIBRARY_PATH"')
+
         return env
 
     def build_env(self, root):


### PR DESCRIPTION
Currently Snapcraft adds only a few standard paths to LD_LIBRARY_PATH. This PR expands that to include paths used by mesa packages.

This will need to be backported to 1.x once approved.

Resolves LP: [#1531620](https://bugs.launchpad.net/snapcraft/+bug/1531620)