### PR TITLE
Backport to 1.x: Close not called on the qml plugin

### DIFF
--- a/snapcraft/plugins/qml.py
+++ b/snapcraft/plugins/qml.py
@@ -69,10 +69,9 @@ class QmlPlugin(snapcraft.BasePlugin):
         arch = snapcraft.common.get_arch_triplet()
         configdir = os.path.join(self.installdir, 'etc', 'xdg', 'qtchooser')
         os.makedirs(configdir, exist_ok=True)
-        config = open(os.path.join(configdir, 'snappy-qt5.conf'), 'w')
-        config.write('./usr/lib/{}/qt5/bin\n'.format(arch))
-        config.write('./usr/lib/{}\n'.format(arch))
-        config.close
+        with open(os.path.join(configdir, 'snappy-qt5.conf'), 'w') as config:
+            config.write('./usr/lib/{}/qt5/bin\n'.format(arch))
+            config.write('./usr/lib/{}\n'.format(arch))
 
     def build(self):
         self._build_qt_config()


### PR DESCRIPTION
Backport of #188 for 1.x