### PR TITLE
Added symlinks option to the copy plugin

### DIFF
--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -36,10 +36,9 @@ class CopyPlugin(snapcraft.BasePlugin):
                 },
                 'follow-symlinks': {
                     'type': 'boolean',
-                    'default': False,
-                    'description': 'symbolic links in the source tree are'
-                                   ' represented as symbolic links'
-                                   ' in the new tree',
+                    'default': True,
+                    'description': 'copy linked file content instead of'
+                                   ' copying only symlink metadata',
                 }
             },
             'required': [
@@ -64,6 +63,7 @@ class CopyPlugin(snapcraft.BasePlugin):
             os.makedirs(os.path.dirname(dst), exist_ok=True)
 
             if os.path.isdir(src):
-                shutil.copytree(src, dst, symlinks=self.options.follow_symlinks)
+                shutil.copytree(
+                    src, dst, symlinks=not self.options.follow_symlinks)
             else:
                 shutil.copy2(src, dst)

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -34,6 +34,13 @@ class CopyPlugin(snapcraft.BasePlugin):
                 'files': {
                     'type': 'object',
                 },
+                'follow-symlinks': {
+                    'type': 'boolean',
+                    'default': False,
+                    'description': 'symbolic links in the source tree are'
+                                   ' represented as symbolic links'
+                                   ' in the new tree',
+                }
             },
             'required': [
                 'files',
@@ -57,6 +64,6 @@ class CopyPlugin(snapcraft.BasePlugin):
             os.makedirs(os.path.dirname(dst), exist_ok=True)
 
             if os.path.isdir(src):
-                shutil.copytree(src, dst)
+                shutil.copytree(src, dst, symlinks=self.options.follow_symlinks)
             else:
                 shutil.copy2(src, dst)

--- a/snapcraft/tests/test_plugin_copy.py
+++ b/snapcraft/tests/test_plugin_copy.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import os.path
 from unittest.mock import Mock
 
@@ -30,6 +31,42 @@ class TestCopyPlugin(TestCase):
         # setup the expected target dir in our tempdir
         self.dst_prefix = 'parts/copy/install/'
         os.makedirs(self.dst_prefix)
+
+    def test_copy_plugin_with_symlink_false_copies_symlinked_file(self):
+        self.mock_options.files = {
+            'src': 'dst'
+        }
+
+        self.mock_options.follow_symlinks = False
+
+        os.makedirs('src')
+        open('src/file.txt', 'w').close()
+        os.symlink('file.txt', 'src/link.txt')
+
+        c = CopyPlugin('copy', self.mock_options)
+        c.build()
+
+        self.assertTrue(
+            os.path.isfile(os.path.join(self.dst_prefix, 'dst/link.txt')))
+        self.assertFalse(
+            os.path.islink(os.path.join(self.dst_prefix, 'dst/link.txt')))
+
+    def test_copy_plugin_with_symlink_true_copies_symlink_itself(self):
+        self.mock_options.files = {
+            'src': 'dst'
+        }
+
+        self.mock_options.follow_symlinks = True
+
+        os.makedirs('src')
+        open('src/file.txt', 'w').close()
+        os.symlink('file.txt', 'src/link.txt')
+
+        c = CopyPlugin('copy', self.mock_options)
+        c.build()
+
+        self.assertTrue(
+            os.path.islink(os.path.join(self.dst_prefix, 'dst/link.txt')))
 
     def test_copy_plugin_any_missing_src_raises_exception(self):
         # ensure that a bad file causes a warning and fails the build even

--- a/snapcraft/tests/test_plugin_copy.py
+++ b/snapcraft/tests/test_plugin_copy.py
@@ -32,12 +32,12 @@ class TestCopyPlugin(TestCase):
         self.dst_prefix = 'parts/copy/install/'
         os.makedirs(self.dst_prefix)
 
-    def test_copy_plugin_with_symlink_false_copies_symlinked_file(self):
+    def test_copy_plugin_with_follow_symlink_true_copies_symlinked_file(self):
         self.mock_options.files = {
             'src': 'dst'
         }
 
-        self.mock_options.follow_symlinks = False
+        self.mock_options.follow_symlinks = True
 
         os.makedirs('src')
         open('src/file.txt', 'w').close()
@@ -51,12 +51,12 @@ class TestCopyPlugin(TestCase):
         self.assertFalse(
             os.path.islink(os.path.join(self.dst_prefix, 'dst/link.txt')))
 
-    def test_copy_plugin_with_symlink_true_copies_symlink_itself(self):
+    def test_copy_plugin_with_follow_symlink_false_copies_symlink_itself(self):
         self.mock_options.files = {
             'src': 'dst'
         }
 
-        self.mock_options.follow_symlinks = True
+        self.mock_options.follow_symlinks = False
 
         os.makedirs('src')
         open('src/file.txt', 'w').close()


### PR DESCRIPTION
We need this change since we need to copy large directories.

Please, consider adding this change to your codebase.

Thank you,
Renat