### PR TITLE
[modified] Added an attribute for defining a destination directory.

### DIFF
--- a/integration_tests/snaps/simple-tar/snapcraft.yaml
+++ b/integration_tests/snaps/simple-tar/snapcraft.yaml
@@ -33,3 +33,7 @@ parts:
     plugin: make
     source: project.tar.xz
     source-type: tar
+  destination-dir:
+    plugin: tar-content
+    source: simple.tar.bz2
+    destination: destdir1/destdir2

--- a/integration_tests/test_tar_plugin.py
+++ b/integration_tests/test_tar_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -40,7 +40,8 @@ class TarPluginTestCase(integration_tests.TestCase):
             'notop',
             'parent',
             'slash',
-            'readonly_file'
+            'readonly_file',
+            os.path.join('destdir1', 'destdir2', 'top-simple')
         ]
         for expected_file in expected_files:
             self.assertThat(
@@ -49,6 +50,8 @@ class TarPluginTestCase(integration_tests.TestCase):
         expected_dirs = [
             'dir-simple',
             'notopdir',
+            'destdir1',
+            os.path.join('destdir1', 'destdir2')
         ]
         for expected_dir in expected_dirs:
             self.assertThat(

--- a/snapcraft/tests/test_plugin_tar_content.py
+++ b/snapcraft/tests/test_plugin_tar_content.py
@@ -1,0 +1,83 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+import tarfile
+from snapcraft.plugins.tar_content import TarContentPlugin
+from snapcraft.tests import TestCase
+
+
+class TestTarContentPlugin(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        # setup the expected target dir in our tempdir
+        self.build_prefix = 'parts/tar_content/build/'
+        os.makedirs(self.build_prefix)
+        self.install_prefix = 'parts/tar_content/install/'
+        os.makedirs(self.install_prefix)
+
+    def test_dest_abs_path_raises_exception(self):
+        class Options:
+            source = '.'
+            destination = '/destdir1'
+        # ensure that a absolute path for a destination directory
+        # raises an exception
+        with self.assertRaises(ValueError) as raised:
+            TarContentPlugin('tar_content', Options())
+
+        self.assertEqual(raised.exception.__str__(),
+                         'path "/destdir1" must be relative')
+
+    def test_build_destination_dir_exists(self):
+        class Options:
+            source = '.'
+            destination = 'destdir1'
+        TarContentPlugin('tar_content', Options())
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.build_prefix, 'destdir1')))
+
+    def test_install_destination_dir_exists(self):
+        class Options:
+            source = os.path.join('src', 'test.tar')
+            destination = 'destdir1'
+
+        # create tar file for testing
+        os.mkdir('src')
+        file_to_tar = os.path.join('src', 'test.txt')
+        open(file_to_tar, 'w').close()
+        tar = tarfile.open(os.path.join('src', 'test.tar'), "w")
+        tar.add(file_to_tar)
+        tar.close()
+
+        t = TarContentPlugin('tar_content', Options())
+        t.build()
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.install_prefix, 'destdir1')))
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(self.install_prefix, 'destdir1/test.txt')))
+
+    def test_without_destination_dir_attribute_defined(self):
+        class Options:
+            source = '.'
+            destination = None
+        TarContentPlugin('tar_content', Options())
+
+        self.assertTrue(
+            os.path.exists(os.path.join(self.build_prefix)))


### PR DESCRIPTION
The tar will be untared to the defined directory in the ../build and
../install directory from the snap. The new attribute "destination" is optional.

Extract from the spancraft.yaml
destination-dir:
      plugin: tar-content
      source: simple.tar.bz2
      destination: destdir1/destdir2