### PR TITLE
Ensure rosdep resolves dependencies using Trusty.

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -419,8 +419,16 @@ class _Rosdep:
 
     def resolve_dependency(self, dependency_name):
         try:
+            # rosdep needs three pieces of information here:
+            #
+            # 1) The dependency we're trying to lookup.
+            # 2) The rosdistro being used.
+            # 3) The version of Ubuntu being used. We're currently using only
+            #    the Trusty ROS sources, so we're telling rosdep to resolve
+            #    dependencies using Trusty (even if we're running on something
+            #    else).
             output = self._run(['resolve', dependency_name, '--rosdistro',
-                                self._ros_distro])
+                                self._ros_distro, '--os', 'ubuntu:trusty'])
         except subprocess.CalledProcessError:
             return None
 

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -718,7 +718,8 @@ class RosdepTestCase(tests.TestCase):
         self.assertEqual(self.rosdep.resolve_dependency('foo'), 'mylib-dev')
 
         self.check_output_mock.assert_called_with(
-            ['rosdep', 'resolve', 'foo', '--rosdistro', 'ros_distro'],
+            ['rosdep', 'resolve', 'foo', '--rosdistro', 'ros_distro', '--os',
+             'ubuntu:trusty'],
             env=mock.ANY)
 
     def test_resolve_invalid_dependency(self):


### PR DESCRIPTION
This PR fixes LP: [#1532241](https://bugs.launchpad.net/snapcraft/+bug/1532241) by instructing rosdep to resolve dependencies using Trusty, even if Snapcraft is not being run on Trusty.

This will need to be cherry-picked to 1.x as well.