### PR TITLE
Backport to 1.x: Replace use of `assert_not_called` in the catkin tests

### DIFF
--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -304,7 +304,8 @@ class CatkinPluginTestCase(tests.TestCase):
 
         bashrun_mock.assert_called_with(check_build_command())
 
-        self.dependencies_mock.assert_not_called(
+        self.assertFalse(
+            self.dependencies_mock.called,
             'Dependencies should have been discovered in the pull() step')
 
         finish_build_mock.assert_called_once_with()
@@ -342,7 +343,8 @@ class CatkinPluginTestCase(tests.TestCase):
 
         bashrun_mock.assert_called_with(check_pkg_arguments(self))
 
-        self.dependencies_mock.assert_not_called(
+        self.assertFalse(
+            self.dependencies_mock.called,
             'Dependencies should have been discovered in the pull() step')
 
         finish_build_mock.assert_called_once_with()
@@ -459,7 +461,8 @@ class CatkinPluginTestCase(tests.TestCase):
             self.assertEqual(f.read(), '#!/usr/bin/env python',
                              'The shebang was not replaced as expected')
 
-        self.dependencies_mock.assert_not_called(
+        self.assertFalse(
+            self.dependencies_mock.called,
             'Dependencies should have been discovered in the pull() step')
 
     @mock.patch.object(catkin.CatkinPlugin, 'run')


### PR DESCRIPTION
Backport of #200 to 1.x.