### PR TITLE
Split the static and unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   #     travis encrypt -r ubuntu-core/snappy COVERALLS_TOKEN=$secret_token
   - secure: JJEh1YfzNJGb1//ca447JtRunHmNXsVDGy5fS882/RQV3XtS9mCaSS+PZF4AbVABSiDw96mvwv05KmhdgV575y0NVHuRPd3rJBku9HOmhOKfCykn5tXgVJUEgeW5HIPusltRkXJUxnm48l+RfHHJU1h6iJnpGjvwxygeQljM4d22+G493ymvv4KZJSnbtuDbmhWvnZtdV2cCFeZ+EWqLgyWaFQmMgeMkYYcY3Cy19d++WquLs4woN9S9szrXJQlIv3xuZ8XNLbWmHoe6uD4y1Fn7YYfRgz861KqusxcGO9OyCh1S6uLgDuETS4Uw2zBg77vv59jSJieEfcY8jQtFE65axot/90jwhp5IV0tIpd9O/AMZXIGqKk44RU+Sj9gDbPbBIhj9dew3BTwSuOcNITSg1a4sOkxHGyIj2NozCkgFqPq0d4RM7xRrOYfnmjP1sJ+tEH4XMbs4gNZ/abccJXeUx6i5qWhDdnix132C62vvl+ItnsfMtkXQ34hluYxoab+rS0Zz3MM/ENqHySvU/R2n7+WTVXHyoK55HvExX7Y+McqPU2uVsHDabmDmQfcYom9nDY1OTBM3JbTOuqtIrzSIlFYdogyttXrTsmSue8TAoWWnHirKdkzeskIs5ZbI/pfGV3eRol+9Mn0MtmaoLp1VrAtSiZYwPRdcIGBDNMQ=
   matrix:
+  - TEST_SUITE=static
   - TEST_SUITE=unit
   - TEST_SUITE=integration
   - TEST_SUITE="examples --skip-install"

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # -*- Mode:sh; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -22,24 +22,27 @@ export PYTHONPATH=$(pwd):$PYTHONPATH
 
 parseargs(){
     if [[ "$#" -eq 0 ]] || [[ "$1" == "all" ]]; then
+        export RUN_STATIC="true"
         export RUN_UNIT="true"
         export RUN_INTEGRATION="true"
         export RUN_EXAMPLES="true"
     else
-        if [ "$1" == "unit" ] ; then
+        if [ "$1" == "static" ] ; then
+            export RUN_STATIC="true"
+        elif [ "$1" == "unit" ] ; then
             export RUN_UNIT="true"
         elif [ "$1" == "integration" ] ; then
             export RUN_INTEGRATION="true"
         elif [ "$1" == "examples" ] ; then
             export RUN_EXAMPLES="true"
         else
-            echo "Not recognized option, should be one of all, unit, integration or examples"
+            echo "Not recognized option, should be one of all, static, unit, integration or examples"
             exit 1
         fi
     fi
 }
 
-run_unit_tests(){
+run_static_tests(){
     SRC_PATHS="bin snapcraft snapcraft/tests examples_tests"
 
     # These three checks could easily be done with flake8 in one shot if
@@ -61,7 +64,9 @@ run_unit_tests(){
         echo "Here's the list of units exceeding 10:"
         echo -e "$mccabe_list"
     fi
+}
 
+run_unit_tests(){
     if which python3-coverage >/dev/null 2>&1; then
         python3-coverage erase
         python3-coverage run --branch --source snapcraft -m unittest discover -s snapcraft -t .
@@ -90,6 +95,10 @@ run_examples(){
 }
 
 parseargs "$@"
+
+if [ ! -z "$RUN_STATIC" ] ; then
+    run_static_tests
+fi
 
 if [ ! -z "$RUN_UNIT" ]; then
     run_unit_tests


### PR DESCRIPTION
@sergiusens wants to run the static checks in something newer than trusty. We can do that with the lxc branch, but we have to split them from the unit tests that we do want to run in trusty.

Fixes LP: [#1533397](https://bugs.launchpad.net/snapcraft/+bug/1533397)