### PR TITLE
Fix environment variable handling

### DIFF
--- a/examples/godd/snapcraft.yaml
+++ b/examples/godd/snapcraft.yaml
@@ -18,4 +18,5 @@ parts:
      - usr/lib/x86_64-linux-gnu/libgudev-1.0.so*
      - usr/lib/x86_64-linux-gnu/libobject-2.0.so*
      - usr/lib/x86_64-linux-gnu/libglib-2.0.so*
+     - lib/x86_64-linux-gnu/libglib-2.0.so*
      - bin/godd*

--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -18,7 +18,6 @@
 
 import os
 import subprocess
-import sys
 import tempfile
 import urllib
 
@@ -60,10 +59,6 @@ def run_output(cmd, **kwargs):
         f.flush()
         return subprocess.check_output(['/bin/sh', f.name] + cmd,
                                        **kwargs).decode('utf8').strip()
-
-
-def fatal():
-    sys.exit(1)
 
 
 def get_arch():


### PR DESCRIPTION
Environment variables now correctly point to stagedir and snapdir and
don't expose the internal installdir paths for a part.

This required an intermediate change in the handling of stage-packages
but it also gives it a semantic meaning by unpacking everything into
the staging directory. Future work can make the handling of
stage-package more transactional or in a single shot.

LP: #1531481