### PR TITLE
Catkin plugin: Use in-snap python instead of OS-provided.

### DIFF
--- a/examples/ros/snapcraft.yaml
+++ b/examples/ros/snapcraft.yaml
@@ -8,10 +8,16 @@ apps:
   rosmaster:
     command: bin/roscore-rosmaster-service
     daemon: simple
+    caps:
+      - network-listener
   listener:
     command: rosrun beginner_tutorials listener
+    caps:
+      - network-listener
   talker:
     command: rosrun beginner_tutorials talker
+    caps:
+      - network-listener
 
 parts:
   roscore:


### PR DESCRIPTION
This works pre-Xenial since python2 is provided on the image. However, it's been removed in Xenial which uncovered this bug. The fix simply rewrites all /usr/bin/python shebangs to use /usr/bin/env python, and also fixes up 10.ros.sh to use python from the path instead of /usr/bin/python.

LP: [#1533297](https://bugs.launchpad.net/snapcraft/+bug/1533297)