### PR TITLE
Always migrate files, even if they already exist.

### DIFF
--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -309,8 +309,16 @@ def _migrate_files(snap_files, snap_dirs, srcdir, dstdir, missing_ok=False):
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         if missing_ok and not os.path.exists(src):
             continue
-        if not os.path.exists(dst) and not os.path.islink(dst):
-            os.link(src, dst, follow_symlinks=False)
+
+        # If the file is already here and it's a symlink, leave it alone.
+        if os.path.islink(dst):
+            continue
+
+        # Otherwise, remove and re-link it.
+        if os.path.exists(dst):
+            os.remove(dst)
+
+        os.link(src, dst, follow_symlinks=False)
 
 
 def _get_file_list(stage_set):

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -181,6 +181,27 @@ class PluginTestCase(tests.TestCase):
 
                 self.assertEqual(expected, result)
 
+    def test_migrate_snap_files_already_exists(self):
+        os.makedirs('install')
+        os.makedirs('stage')
+
+        # Place the already-staged file
+        with open('stage/foo', 'w') as f:
+            f.write('staged')
+
+        # Place the to-be-staged file with the same name
+        with open('install/foo', 'w') as f:
+            f.write('installed')
+
+        files, dirs = pluginhandler._migratable_filesets('*', 'install')
+        pluginhandler._migrate_files(files, dirs, 'install', 'stage')
+
+        # Verify that the staged file is the one that was staged last
+        with open('stage/foo', 'r') as f:
+            self.assertEqual(f.read(), 'installed',
+                             'Expected staging to allow overwriting of '
+                             'already-staged files')
+
     @patch('snapcraft.pluginhandler._load_local')
     @patch('snapcraft.pluginhandler._get_plugin')
     def test_schema_not_found(self, plugin_mock, local_load_mock):


### PR DESCRIPTION
This prevents files contained in a stage-package .deb from taking precedence over files of the same name produced in the part. The migration is done via hard linking, which means this doesn't add any noticeable delay.

LP: [#1534800](https://bugs.launchpad.net/snapcraft/+bug/1534800)