### PR TITLE
Backport to 1.x: Go plugin creating invalid env

### DIFF
--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -70,7 +70,7 @@ class GoPlugin(snapcraft.BasePlugin):
         # usr/lib/go/bin on newer Ubuntus, usr/bin on trusty
         env = [
             'GOPATH={}/go'.format(root),
-            'CGO_LDFLAGS=$CGO_LDFLAGS"' + ' '.join([
+            'CGO_LDFLAGS="$CGO_LDFLAGS ' + ' '.join([
                 '-L{0}/lib',
                 '-L{0}/usr/lib',
                 '-L{0}/lib/{1}',

--- a/snapcraft/tests/test_plugin_go.py
+++ b/snapcraft/tests/test_plugin_go.py
@@ -44,7 +44,7 @@ class GoPluginTestCase(tests.TestCase):
         plugin = go.GoPlugin('test', Options())
         self.assertEqual(plugin.env('myroot'), [
             'GOPATH=myroot/go',
-            'CGO_LDFLAGS=$CGO_LDFLAGS"-Lmyroot/lib -Lmyroot/usr/lib '
+            'CGO_LDFLAGS="$CGO_LDFLAGS -Lmyroot/lib -Lmyroot/usr/lib '
             '-Lmyroot/lib/{0} '
             '-Lmyroot/usr/lib/{0} $LDFLAGS"'.format(
                 common.get_arch_triplet())])


### PR DESCRIPTION
Backport of #161 to 1.x.