### PR TITLE
Git source: Make a shallow clone.

### DIFF
--- a/snapcraft/sources.py
+++ b/snapcraft/sources.py
@@ -127,7 +127,7 @@ class Git(Base):
             if self.source_tag or self.source_branch:
                 branch_opts = ['--branch',
                                self.source_tag or self.source_branch]
-            cmd = ['git', 'clone'] + branch_opts + \
+            cmd = ['git', 'clone', '--depth', '1'] + branch_opts + \
                   [self.source, self.source_dir]
 
         subprocess.check_call(cmd)

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -136,7 +136,7 @@ class TestGit(SourceTestCase):
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', 'git://my-source', 'source_dir'])
+            ['git', 'clone', '--depth', '1', 'git://my-source', 'source_dir'])
 
     def test_pull_branch(self):
         git = snapcraft.sources.Git('git://my-source', 'source_dir',
@@ -144,8 +144,8 @@ class TestGit(SourceTestCase):
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--branch', 'my-branch', 'git://my-source',
-             'source_dir'])
+            ['git', 'clone', '--depth', '1', '--branch', 'my-branch',
+             'git://my-source', 'source_dir'])
 
     def test_pull_tag(self):
         git = snapcraft.sources.Git('git://my-source', 'source_dir',
@@ -153,8 +153,8 @@ class TestGit(SourceTestCase):
         git.pull()
 
         self.mock_run.assert_called_once_with(
-            ['git', 'clone', '--branch', 'tag', 'git://my-source',
-             'source_dir'])
+            ['git', 'clone', '--depth', '1', '--branch', 'tag',
+             'git://my-source', 'source_dir'])
 
     def test_pull_existing(self):
         self.mock_path_exists.return_value = True


### PR DESCRIPTION
This PR resolves LP: [#1536696](https://bugs.launchpad.net/snapcraft/+bug/1536696) by making the git source use a shallow (depth of 1) clone rather than fetching the entire history.