### PR TITLE
Backport to 1.x: Autotools plugin: Call make before make install

### DIFF
--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -83,4 +83,5 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
             else:
                 self.run(['autoreconf', '-i'])
         self.run(['./configure', '--prefix='] + self.options.configflags)
+        self.run(['make'])
         self.run(['make', 'install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/tests/test_plugin_autotools.py
+++ b/snapcraft/tests/test_plugin_autotools.py
@@ -90,9 +90,10 @@ class AutotoolsPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(2, run_mock.call_count)
+        self.assertEqual(3, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix=']),
+            mock.call(['make']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -109,10 +110,11 @@ class AutotoolsPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
+            mock.call(['make']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -126,10 +128,11 @@ class AutotoolsPluginTestCase(tests.TestCase):
 
         plugin.build()
 
-        self.assertEqual(3, run_mock.call_count)
+        self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
+            mock.call(['make']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])


### PR DESCRIPTION
Backport of #253 for 1.x.