### PR TITLE
Make plugin: Support non-standard makefile name.

### DIFF
--- a/integration_tests/snaps/simple-make-nonstandard-makefile/makefile.linux
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/makefile.linux
@@ -1,0 +1,8 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+	gcc -o test test.c
+
+install:
+	mkdir -p $(DESTDIR)/bin
+	cp -a test $(DESTDIR)/bin/

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
@@ -1,0 +1,10 @@
+name: test-package
+version: 0.1
+summary: one line summary
+description: a longer description
+
+parts:
+  make-project:
+    plugin: make
+    source: .
+    makefile: makefile.linux

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/test.c
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/test.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+int main() {
+    printf("Hello world\n");
+}

--- a/integration_tests/test_make_plugin.py
+++ b/integration_tests/test_make_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -48,3 +48,12 @@ class MakePluginTestCase(integration_tests.TestCase):
         for dir_ in snap_dirs:
             self.assertThat(
                 os.path.join(project_dir, dir_), Not(DirExists()))
+
+    def test_nonstandard_makefile(self):
+        project_dir = 'simple-make-nonstandard-makefile'
+        self.run_snapcraft('stage', project_dir)
+
+        binary_output = self.get_output_ignoring_non_zero_exit(
+            os.path.join('stage', 'bin', 'test'),
+            cwd=project_dir)
+        self.assertEqual('Hello world\n', binary_output)

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,12 @@ build.
 This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keyword:
+
+    - makefile:
+      (string)
+      Use the given file as the makefile.
 """
 
 import snapcraft
@@ -29,11 +35,26 @@ import snapcraft
 
 class MakePlugin(snapcraft.BasePlugin):
 
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['makefile'] = {
+            'type': 'string'
+        }
+
+        return schema
+
     def __init__(self, name, options):
         super().__init__(name, options)
         self.build_packages.append('make')
 
     def build(self):
         super().build()
-        self.run(['make'])
-        self.run(['make', 'install', 'DESTDIR=' + self.installdir])
+
+        command = ['make']
+
+        if self.options.makefile:
+            command.extend(['-f', self.options.makefile])
+
+        self.run(command)
+        self.run(command + ['install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -1,0 +1,82 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from unittest import mock
+
+from snapcraft import tests
+from snapcraft.plugins import make
+
+
+class MakePluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            makefile = None
+
+        self.options = Options()
+
+        patcher = mock.patch('snapcraft.repo.Ubuntu')
+        self.ubuntu_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_schema(self):
+        schema = make.MakePlugin.schema()
+
+        properties = schema['properties']
+        self.assertTrue('makefile' in properties,
+                        'Expected "makefile" to be included in properties')
+
+        makefile = properties['makefile']
+        self.assertTrue('type' in makefile,
+                        'Expected "type" to be included in "makefile"')
+
+        makefile_type = makefile['type']
+        self.assertEqual(makefile_type, 'string',
+                         'Expected "makefile" "type" to be "string", but it '
+                         'was "{}"'.format(makefile_type))
+
+    @mock.patch.object(make.MakePlugin, 'run')
+    def test_build(self, run_mock):
+        plugin = make.MakePlugin('test-part', self.options)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.assertEqual(2, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make']),
+            mock.call(['make', 'install',
+                       'DESTDIR={}'.format(plugin.installdir)])
+        ])
+
+    @mock.patch.object(make.MakePlugin, 'run')
+    def test_build_makefile(self, run_mock):
+        self.options.makefile = 'makefile.linux'
+        plugin = make.MakePlugin('test-part', self.options)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.build()
+
+        self.assertEqual(2, run_mock.call_count)
+        run_mock.assert_has_calls([
+            mock.call(['make', '-f', 'makefile.linux']),
+            mock.call(['make', '-f', 'makefile.linux', 'install',
+                       'DESTDIR={}'.format(plugin.installdir)])
+        ])


### PR DESCRIPTION
This PR fixes LP: [#1500759](https://bugs.launchpad.net/snapcraft/+bug/1500759) by adding a "makefile" property to the Make plugin, which, if specified, results in a `make -f <makefile>` instead of just `make`. This supports projects with makefiles named e.g. makefile.linux, etc.