### PR TITLE
Support $SNAPCRAFT_STAGE for parts

### DIFF
--- a/docs/snapcraft-advanced-features.md
+++ b/docs/snapcraft-advanced-features.md
@@ -127,6 +127,25 @@ will be built after `libpipeline`. Especially if you need specific
 functionality during a build or as part of checks during the `stage` phase,
 this will be handy.
 
+If any part built using the `after` keyword needs to explicitly access
+assets in the stage directory with configuration flags (e.g.; `configure`
+in the case of autotools) it can use of the `SNAPCRAFT_STAGE` environment
+variable, like this:
+
+```yaml
+parts:
+    my-part:
+        plugin: autotools
+        source: .
+        configFlags:
+            - --with-swig $SNAPCRAFT_STAGE/swig
+        after:
+            - swig
+    swig:
+        plugin: autotools
+        source: ./swig
+```
+
 ### Re-using parts
 
 With snapcraft we want to make it easy to learn from other app vendors and

--- a/integration_tests/snaps/stage_env/CMakeLists.txt
+++ b/integration_tests/snaps/stage_env/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.2)
+project(simple-cmake)
+
+IF(NOT DEFINED DEP_DIR)
+    message(FATAL_ERROR "DEP_DIR is not defined.")
+ENDIF(NOT DEFINED DEP_DIR)
+
+# This is here to test $SNAPCRAFT_STAGE
+IF(NOT EXISTS "${DEP_DIR}/s")
+    message(FATAL_ERROR "${DEP_DIR}/s does not exist.")
+ENDIF(NOT EXISTS "${DEP_DIR}/s")
+
+file(WRITE my-file "stub file")
+install(FILES my-file DESTINATION share)

--- a/integration_tests/snaps/stage_env/snapcraft.yaml
+++ b/integration_tests/snaps/stage_env/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: test-package
+version: 0.1
+summary: try out $SNAPCRAFT_STAGE
+description: |
+  The cmake-project expects to have a copied directory in the stage directory
+  to consume during its build time.
+
+parts:
+  cmake-project:
+    plugin: cmake
+    source: .
+    configflags:
+        - -DDEP_DIR=$SNAPCRAFT_STAGE/copied
+    after:
+      - copy
+  copy:
+    plugin: copy
+    files:
+        copied: copied

--- a/integration_tests/test_after.py
+++ b/integration_tests/test_after.py
@@ -86,3 +86,8 @@ class AfterTestCase(integration_tests.TestCase):
         self.assertRaises(
             subprocess.CalledProcessError,
             self.run_snapcraft, 'pull', project_dir)
+
+    def test_snapcraft_stage_env_replacement(self):
+        project_dir = 'stage_env'
+
+        self.run_snapcraft('stage', project_dir)

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -355,3 +355,193 @@ class CollisionTestCase(tests.TestCase):
             raised.exception.__str__(),
             "Parts 'part2' and 'part3' have the following file paths in "
             "common which have different contents:\n1\na/2")
+
+
+class StageEnvTestCase(tests.TestCase):
+
+    def test_string_replacements(self):
+        stagedir = common.get_stagedir()
+
+        replacements = (
+            (
+                'no replacement',
+                'snapcraft_stage/usr/bin',
+                'snapcraft_stage/usr/bin',
+            ),
+            (
+                'replaced start',
+                '$SNAPCRAFT_STAGE/usr/bin',
+                '{}/usr/bin'.format(stagedir),
+            ),
+            (
+                'replaced between',
+                '--with-swig $SNAPCRAFT_STAGE/usr/swig',
+                '--with-swig {}/usr/swig'.format(stagedir),
+            ),
+        )
+
+        for test_name, subject, expected in replacements:
+            self.subTest(key=test_name)
+            self.assertEqual(pluginhandler._expand_env(subject), expected)
+
+    def test_lists_with_string_replacements(self):
+        stagedir = common.get_stagedir()
+
+        replacements = (
+            (
+                'no replacement',
+                [
+                    'snapcraft_stage/usr/bin',
+                    '/usr/bin',
+                ],
+                [
+                    'snapcraft_stage/usr/bin',
+                    '/usr/bin',
+                ],
+            ),
+            (
+                'replaced start',
+                [
+                    '$SNAPCRAFT_STAGE/usr/bin',
+                    '/usr/bin',
+                ],
+                [
+                    '{}/usr/bin'.format(stagedir),
+                    '/usr/bin',
+                ],
+            ),
+            (
+                'replaced between',
+                [
+                    '--without-python',
+                    '--with-swig $SNAPCRAFT_STAGE/usr/swig',
+                ],
+                [
+                    '--without-python',
+                    '--with-swig {}/usr/swig'.format(stagedir),
+                ],
+            ),
+        )
+
+        for test_name, subject, expected in replacements:
+            self.subTest(key=test_name)
+            self.assertEqual(pluginhandler._expand_env(subject), expected)
+
+    def test_tuples_with_string_replacements(self):
+        stagedir = common.get_stagedir()
+
+        replacements = (
+            (
+                'no replacement',
+                (
+                    'snapcraft_stage/usr/bin',
+                    '/usr/bin',
+                ),
+                [
+                    'snapcraft_stage/usr/bin',
+                    '/usr/bin',
+                ],
+            ),
+            (
+                'replaced start',
+                (
+                    '$SNAPCRAFT_STAGE/usr/bin',
+                    '/usr/bin',
+                ),
+                [
+                    '{}/usr/bin'.format(stagedir),
+                    '/usr/bin',
+                ],
+            ),
+            (
+                'replaced between',
+                (
+                    '--without-python',
+                    '--with-swig $SNAPCRAFT_STAGE/usr/swig',
+                ),
+                [
+                    '--without-python',
+                    '--with-swig {}/usr/swig'.format(stagedir),
+                ],
+            ),
+        )
+
+        for test_name, subject, expected in replacements:
+            self.subTest(key=test_name)
+            self.assertEqual(pluginhandler._expand_env(subject), expected)
+
+    def test_dict_with_string_replacements(self):
+        stagedir = common.get_stagedir()
+
+        replacements = (
+            (
+                'no replacement',
+                {
+                    '1': 'snapcraft_stage/usr/bin',
+                    '2': '/usr/bin',
+                },
+                {
+                    '1': 'snapcraft_stage/usr/bin',
+                    '2': '/usr/bin',
+                },
+            ),
+            (
+                'replaced start',
+                {
+                    '1': '$SNAPCRAFT_STAGE/usr/bin',
+                    '2': '/usr/bin',
+                },
+                {
+                    '1': '{}/usr/bin'.format(stagedir),
+                    '2': '/usr/bin',
+                },
+            ),
+            (
+                'replaced between',
+                {
+                    '1': '--without-python',
+                    '2': '--with-swig $SNAPCRAFT_STAGE/usr/swig',
+                },
+                {
+                    '1': '--without-python',
+                    '2': '--with-swig {}/usr/swig'.format(stagedir),
+                },
+            ),
+        )
+
+        for test_name, subject, expected in replacements:
+            self.subTest(key=test_name)
+            self.assertEqual(pluginhandler._expand_env(subject), expected)
+
+    def test_string_replacement_with_complex_data(self):
+        stagedir = common.get_stagedir()
+
+        subject = {
+            'filesets': {
+                'files': [
+                    'somefile',
+                    '$SNAPCRAFT_STAGE/file1',
+                    'SNAPCRAFT_STAGE/really',
+                ]
+            },
+            'configFlags': [
+                '--with-python',
+                '--with-swig $SNAPCRAFT_STAGE/swig',
+            ],
+        }
+
+        expected = {
+            'filesets': {
+                'files': [
+                    'somefile',
+                    '{}/file1'.format(stagedir),
+                    'SNAPCRAFT_STAGE/really',
+                ]
+            },
+            'configFlags': [
+                '--with-python',
+                '--with-swig {}/swig'.format(stagedir),
+            ],
+        }
+
+        self.assertEqual(pluginhandler._expand_env(subject), expected)


### PR DESCRIPTION
When a part is loaded, instances of $SNAPCRAFT_STAGE
are replaced with the absolute path to the stage directory
during runtime.

LP: #1538688