### PR TITLE
Add documentation for how to use snapcraft upload.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -32,8 +32,24 @@ You can install the daily build PPA by running:
 We'd love the help!
 
 - Submit pull requests against [snapcraft](https://github.com/ubuntu-core/snapcraft/pulls)
+- Make sure to read the [contribution guide](CONTRIBUTING.md)
 - Our mailing list is snappy-devel@lists.ubuntu.com
 - We can also be found on the #snappy IRC channel on Freenode
+
+
+### Staging server
+
+Snapcraft has the ability to upload snaps for publication in the Snappy Store.
+If you're working on a feature that requires you to interact with the store, you
+might want to use the staging server instead of the production store. To do
+that, make sure you have an account on the
+[staging server](https://login.staging.ubuntu.com), then set the following
+environment variables:
+
+    UBUNTU_STORE_API_ROOT_URL='https://myapps.developer.staging.ubuntu.com/dev/api/'
+    UBUNTU_STORE_UPLOAD_ROOT_URL='https://upload.apps.staging.ubuntu.com/'
+    UBUNTU_SSO_API_ROOT_URL='https://login.staging.ubuntu.com/api/v2/'
+
 
 ### Project Layout
 

--- a/docs/upload-your-snap.md
+++ b/docs/upload-your-snap.md
@@ -1,0 +1,55 @@
+# Upload to the store
+
+So you've been working hard on your snap, and you finally have it to the point
+where you're ready to share it with the world? Great! You can use Snapcraft to
+upload it directly to the store.
+
+
+## Authenticate to the store
+
+First of all, you need to give Snapcraft permission to communicate with the
+store on your behalf:
+
+    $ snapcraft login
+    Enter your Ubuntu One SSO credentials.
+    Email: me@example.com
+    Password:
+    OTP: <press enter here if you haven't enabled two-factor authentication>
+    Authenticating against Ubuntu One SSO.
+    Starting new HTTPS connection (1): login.ubuntu.com
+    Login successful.
+
+These credentials will remain valid until you revoke them, which you can do
+with the following:
+
+    $ snapcraft logout
+    Clearing credentials for Ubuntu One SSO.
+    Credentials cleared.
+
+Now, let's upload that snap!
+
+
+## Upload the snap
+
+Get into the directory containing the `snapcraft.yaml`, and do the following:
+
+    $ snapcraft upload
+    Uploading foo_1_amd64.snap
+    Uploading files...
+    Starting new HTTPS connection (1): upload.apps.ubuntu.com
+    Uploading new version...
+    Starting new HTTPS connection (1): myapps.developer.ubuntu.com
+    Package submitted to https://myapps.developer.ubuntu.com/dev/api/click-package-upload/foo/
+    Checking package status...
+    Package scan completed.
+    Application uploaded successfully.
+    Uploaded as revision 1.
+    Please check out the application at: https://myapps.ubuntu.com/dev/click-apps/1337/.
+
+    foo_1_amd64.snap upload complete
+
+Your snap has now been uploaded to the store, and is now undergoing an
+automated review. You'll be emailed when the review has completed, at which time
+you can visit the MyApps site and publish your snap! Note that if you uploaded
+a new version for an already-published snap, your update will be automatically
+published.

--- a/docs/your-first-snap.md
+++ b/docs/your-first-snap.md
@@ -323,7 +323,8 @@ We'll be happy to help you on the mailing list to build a snappy package of
 anything that you are interested in. Choose a good name for it, and you can
 very easily share it in
 [ubuntu myapps](https://myapps.developer.ubuntu.com/dev/click-apps/?format=snap)
-where you go to share it with other snappy users.
+where you go to share it with other snappy users. You can even use Snapcraft to
+[upload for you](upload-your-snap.md)!
 
 This is the same underlying hub that we use for Ubuntu phone apps, but
 snappy is a new iteration of that system. It only takes minutes from time of


### PR DESCRIPTION
This PR resolves LP: [#1539234](https://bugs.launchpad.net/snapcraft/+bug/1539234) by adding a document that walks a developer through uploading a snap.