### PR TITLE
Make package installation dynamic to reduce deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - sudo lxc config device add xenial /dev/sda1 disk source=$(pwd) path=$(pwd)
   # Install the snapcraft dependencies.
   - sudo lxc exec xenial -- apt-get update
-  - sudo lxc exec xenial -- apt-get install -y build-essential bzr dpkg-dev git mercurial pyflakes python-flake8 python3.4 python3-apt python3-docopt python3-coverage python3-fixtures python3-flake8 python3-jsonschema python3-mccabe python3-mock python3-pep8 python3-pip python3-requests python3-requests-oauthlib python3-responses python3-ssoclient python3-testscenarios python3-testtools python3-xdg python3-yaml python3-lxml squashfs-tools
+  - sudo lxc exec xenial -- apt-get install -y pyflakes python-flake8 python3.5 python3-apt python3-docopt python3-coverage python3-fixtures python3-flake8 python3-jsonschema python3-mccabe python3-mock python3-pep8 python3-pip python3-requests python3-requests-oauthlib python3-responses python3-ssoclient python3-testscenarios python3-testtools python3-xdg python3-yaml python3-lxml squashfs-tools
 script:
   - sudo -E lxc exec xenial -- su - ubuntu -c "cd $(pwd); ./runtests.sh $TEST_SUITE"
 after_success:

--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,7 @@ Source: snapcraft
 Section: utils
 Priority: extra
 Maintainer: Snapcraft Team <snappy-devel@lists.ubuntu.com>
-Build-Depends: bzr,
-               cmake,
-               debhelper (>= 9),
+Build-Depends: debhelper (>= 9),
                dh-python,
                python3 (>= 3.4),
                python3-apt,
@@ -21,19 +19,13 @@ Build-Depends: bzr,
                python3-testscenarios,
                python3-xdg,
                python3-yaml,
-               wget,
-               xz-utils
 Homepage: https://github.com/ubuntu-core/snapcraft
 Vcs-Git: https://github.com/ubuntu-core/snapcraft
 Standards-Version: 3.9.6
 
 Package: snapcraft
 Architecture: all
-Depends: bzr,
-         dpkg-dev,
-         git,
-         mercurial,
-         python3-apt,
+Depends: python3-apt,
          python3-docopt,
          python3-jsonschema,
          python3-lxml,
@@ -45,8 +37,6 @@ Depends: bzr,
          python3-yaml,
          squashfs-tools,
          sudo,
-         wget,
-         xz-utils,
          ${misc:Depends},
          ${python3:Depends}
 Description: easily craft snaps

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,7 +1,6 @@
 Tests: integrationtests examplestests
 Restrictions: allow-stderr, isolation-container, rw-build-tree
 Depends: @,
-         build-essential,
          python3-pep8,
          pyflakes,
          python-flake8,

--- a/examples/godd/snapcraft.yaml
+++ b/examples/godd/snapcraft.yaml
@@ -14,6 +14,7 @@ parts:
     plugin: go
     source: https://github.com/mvo5/godd
     source-type: git
+    build-packages: [gcc]
     stage-packages: [libgudev-1.0-dev]
     snap:
      - usr/lib/x86_64-linux-gnu/libgudev-1.0.so*

--- a/examples/py2-project/snapcraft.yaml
+++ b/examples/py2-project/snapcraft.yaml
@@ -13,6 +13,7 @@ parts:
     plugin: python2
     source: https://github.com/markokr/spongeshaker.git
     source-type: git
+    build-packages: [gcc, libc6-dev]
   make-project:
     plugin: make
     source: .

--- a/examples/py3-project/snapcraft.yaml
+++ b/examples/py3-project/snapcraft.yaml
@@ -13,6 +13,7 @@ parts:
     plugin: python3
     source: https://github.com/markokr/spongeshaker.git
     source-type: git
+    build-packages: [gcc, libc6-dev]
   sha3:
     plugin: copy
     files:

--- a/integration_tests/test_bzr_source.py
+++ b/integration_tests/test_bzr_source.py
@@ -23,6 +23,7 @@ import integration_tests
 class BzrSourceTestCase(integration_tests.TestCase):
 
     def _init_and_config_bzr(self):
+        subprocess.check_call(['sudo', 'apt-get', 'install', '-y', 'bzr'])
         subprocess.check_call(
             ['bzr', 'init', '.'],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -23,6 +23,7 @@ import integration_tests
 class GitSourceTestCase(integration_tests.TestCase):
 
     def _init_and_config_git(self):
+        subprocess.check_call(['sudo', 'apt-get', 'install', '-y', 'git'])
         subprocess.check_call(
             ['git', 'init', '.'], stdout=subprocess.DEVNULL)
         subprocess.check_call(

--- a/integration_tests/test_hg_source.py
+++ b/integration_tests/test_hg_source.py
@@ -24,6 +24,11 @@ import integration_tests
 
 class HgSourceTestCase(integration_tests.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        subprocess.check_call(
+            ['sudo', 'apt-get', 'install', '-y', 'mercurial'])
+
     def _get_hg_revno(self, path):
         return subprocess.check_output(
             ['hg', 'log', '--cwd', path, '--template',

--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -17,6 +17,7 @@
 # Data/methods shared between plugins and snapcraft
 
 import os
+import platform
 import subprocess
 import tempfile
 import urllib
@@ -29,7 +30,6 @@ _plugindir = _DEFAULT_PLUGINDIR
 _DEFAULT_SCHEMADIR = '/usr/share/snapcraft/schema'
 _schemadir = _DEFAULT_SCHEMADIR
 _arch = None
-_arch_triplet = None
 
 env = []
 
@@ -61,21 +61,46 @@ def run_output(cmd, **kwargs):
                                        **kwargs).decode('utf8').strip()
 
 
+_DEB_TRANSLATIONS = {
+    'armv7l': {
+        'arch': 'armhf',
+        'triplet': 'arm-linux-gnueabihf',
+    },
+    'aarch64': {
+        'arch': 'arm64',
+        'triplet': 'aarch64-linux-gnu',
+    },
+    'i686': {
+        'arch': 'i386',
+        'triplet': 'i386-linux-gnu',
+    },
+    'ppc64le': {
+        'arch': 'ppc64el',
+        'triplet': 'powerpc64le-linux-gnu',
+    },
+    'x86_64': {
+        'arch': 'amd64',
+        'triplet': 'x86_64-linux-gnu',
+    }
+}
+
+
 def get_arch():
-    global _arch
-    if _arch is None:
-        _arch = subprocess.check_output(
-            ['dpkg-architecture', '-qDEB_BUILD_ARCH']).decode('utf8').strip()
-    return _arch
+    try:
+        return _DEB_TRANSLATIONS[platform.machine()]['arch']
+    except KeyError:
+        raise EnvironmentError(
+            '{} is not supported, please log a bug at'
+            'https://bugs.launchpad.net/snapcraft'.format(platform.machine()))
 
 
 def get_arch_triplet():
-    global _arch_triplet
-    if _arch_triplet is None:
-        _arch_triplet = subprocess.check_output(
-            ['dpkg-architecture', '-qDEB_BUILD_MULTIARCH']
-        ).decode('utf8').strip()
-    return _arch_triplet
+    try:
+        return _DEB_TRANSLATIONS[platform.machine()]['triplet']
+    except KeyError:
+        raise EnvironmentError(
+            '{} is not supported, please log a bug at'
+            'https://bugs.launchpad.net/snapcraft'.format(platform.machine()))
 
 
 def get_partsdir():

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -150,6 +150,62 @@ parts:
         mock_load.assert_has_calls([call1, call2])
         self.assertTrue(mock_get_part.called)
 
+    def test_config_adds_vcs_packages_to_build_packages(self):
+        scenarios = [
+            ('git://github.com/ubuntu-core/snapcraft.git', 'git'),
+            ('lp:ubuntu-push', 'bzr'),
+            ('https://github.com/ubuntu-core/snapcraft/archive/2.0.1.tar.gz',
+             'tar'),
+        ]
+        yaml_t = """name: test
+version: "1"
+summary: test
+description: test
+
+parts:
+  part1:
+    source: {0}
+    plugin: autotools
+"""
+
+        for s in scenarios:
+            with self.subTest(key=(s[1])):
+                self.make_snapcraft_yaml(yaml_t.format(s[0]))
+                c = snapcraft.yaml.Config()
+
+                self.assertTrue(
+                    s[1] in c.build_tools,
+                    '{} not found in {}'.format(s[1], c.build_tools))
+
+    def test_config_adds_vcs_packages_to_build_packages_from_types(self):
+        scenarios = [
+            ('git', 'git'),
+            ('hg', 'mercurial'),
+            ('mercurial', 'mercurial'),
+            ('bzr', 'bzr'),
+            ('tar', 'tar'),
+        ]
+        yaml_t = """name: test
+version: "1"
+summary: test
+description: test
+
+parts:
+  part1:
+    source: http://something/somewhere
+    source-type: {0}
+    plugin: autotools
+"""
+
+        for s in scenarios:
+            with self.subTest(key=(s[1])):
+                self.make_snapcraft_yaml(yaml_t.format(s[0]))
+                c = snapcraft.yaml.Config()
+
+                self.assertTrue(
+                    s[1] in c.build_tools,
+                    '{} not found in {}'.format(s[1], c.build_tools))
+
     def test_config_raises_on_missing_snapcraft_yaml(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -28,6 +28,7 @@ from snapcraft import (
     common,
     libraries,
     pluginhandler,
+    sources,
     wiki,
 )
 
@@ -202,6 +203,7 @@ class Config:
             part_name, plugin_name, properties)
 
         self.build_tools += part.code.build_packages
+        self.build_tools += sources.get_required_packages(part.code.options)
         self.all_parts.append(part)
         return part
 


### PR DESCRIPTION
debian/control has a huge amount of dependencies that could very well
be installed depending on the project. There are also dependencies
included that are not relevant anymore.

The work here:

- cleans up debian/control
- adds logic to install the correct vcs tool depending on the source
  in snapcraft.yaml
- makes sure all the examples have complete dependencies
- cleans up .travis.yml

LP: #1539146