### PR TITLE
Use the log fixture for logging by default for ut

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import tempfile
 
@@ -51,6 +52,7 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
         self.addCleanup(common.reset_env)
         common.set_schemadir(os.path.join(__file__,
                              '..', '..', '..', 'schema'))
+        self.useFixture(fixtures.FakeLogger(level=logging.ERROR))
 
     def make_snapcraft_yaml(self, content, encoding='utf-8'):
         tempdir_obj = tempfile.TemporaryDirectory()

--- a/snapcraft/tests/test_storeapi_upload.py
+++ b/snapcraft/tests/test_storeapi_upload.py
@@ -17,11 +17,11 @@ from __future__ import absolute_import, unicode_literals
 import json
 import os
 import tempfile
-from unittest import TestCase
 
 from mock import ANY, call, patch
 from requests import Response
 
+from snapcraft import tests
 from snapcraft.storeapi._upload import (
     get_upload_url,
     upload_app,
@@ -30,7 +30,7 @@ from snapcraft.storeapi._upload import (
 )
 
 
-class UploadBaseTestCase(TestCase):
+class UploadBaseTestCase(tests.TestCase):
 
     def setUp(self):
         super(UploadBaseTestCase, self).setUp()
@@ -313,7 +313,7 @@ class UploadFilesTestCase(UploadBaseTestCase):
 class UploadAppTestCase(UploadBaseTestCase):
 
     def setUp(self):
-        super(UploadAppTestCase, self).setUp()
+        super().setUp()
         self.data = {
             'upload_id': 'some-valid-upload-id',
             'binary_filesize': 123456,


### PR DESCRIPTION
Unit tests now have the logging fixture set by default to avoid leaking
messages to the console

LP: #1539817