### PR TITLE
Add gcc as build-packages to integration tests

### DIFF
--- a/integration_tests/snaps/conflicts/snapcraft.yaml
+++ b/integration_tests/snaps/conflicts/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc]
+
 parts:
   p1:
     plugin: make

--- a/integration_tests/snaps/dependencies/snapcraft.yaml
+++ b/integration_tests/snaps/dependencies/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc]
 parts:
   p1:
     plugin: make

--- a/integration_tests/snaps/simple-cmake/snapcraft.yaml
+++ b/integration_tests/snaps/simple-cmake/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc]
+
 parts:
   cmake-project:
     plugin: cmake

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
@@ -3,6 +3,8 @@ version: 0.1
 summary: one line summary
 description: a longer description
 
+build-packages: [gcc]
+
 parts:
   make-project:
     plugin: make

--- a/integration_tests/snaps/simple-make/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc]
+
 parts:
   make-project:
     plugin: make

--- a/integration_tests/snaps/simple-scons/snapcraft.yaml
+++ b/integration_tests/snaps/simple-scons/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: test a simple scons project
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc]
+
 parts:
   scons-project:
     scons-options:

--- a/integration_tests/snaps/wiki/snapcraft.yaml
+++ b/integration_tests/snaps/wiki/snapcraft.yaml
@@ -4,11 +4,13 @@ summary: Test using a wiki part to complete the local part
 description:
  As the plugin keyword is not defined and the curl part exists on the
  wiki, this part will use data from the wiki to have all the necessary
- information to build. 
- 
+ information to build.
+
  In this case the wiki defines it wants curl 7.44.0 and we are telling
  it to use 7.45.0
 icon: icon.png
+
+build-packages: [gcc]
 
 parts:
   curl:


### PR DESCRIPTION
Most of the integration tests require gcc as a build-package.

LP: #1541332