### PR TITLE
Backport to 1.x: Fix FD leakage by closing apt cache in repo.py

### DIFF
--- a/snapcraft/cmds.py
+++ b/snapcraft/cmds.py
@@ -348,20 +348,24 @@ def _check_call(args, **kwargs):
 
 
 def _install_build_packages(packages):
+    unique_packages = set(packages)
     new_packages = []
-    for pkg in packages:
-        try:
-            if not apt.Cache()[pkg].installed:
-                new_packages.append(pkg)
-        except KeyError:
-            logger.error('Could not find all the "build-packages" required '
-                         'in snapcraft.yaml')
-            sys.exit(1)
+    with apt.Cache() as apt_cache:
+        for pkg in unique_packages:
+            try:
+                if not apt_cache[pkg].installed:
+                    new_packages.append(pkg)
+            except KeyError:
+                logger.error('Could not find all the "build-packages" '
+                             'required in snapcraft.yaml')
+                sys.exit(1)
     if new_packages:
-        logger.info('Installing required packages on the host system')
-        _check_call(['sudo', 'apt-get', '-o', 'Dpkg::Progress-Fancy=1',
-                     '--no-install-recommends',
-                     '-y', 'install'] + new_packages)
+        logger.info(
+            'Installing build dependencies: %s', ' '.join(new_packages))
+        subprocess.check_call(['sudo', 'apt-get', '-o',
+                               'Dpkg::Progress-Fancy=1',
+                               '--no-install-recommends',
+                               '-y', 'install'] + new_packages)
 
 
 def _load_config():


### PR DESCRIPTION
Backport of #268 for 1.x.

Note that in 1.x this wasn't actually in repy.py, but in cmds.py.