### PR TITLE
Snap: When snapping a directory, look for snap.yaml.

### DIFF
--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -82,6 +82,20 @@ class SnapTestCase(integration_tests.TestCase):
         self.assertThat(
             os.path.join('snap', 'bin', 'not-wrapped.wrapper'),
             Not(FileExists()))
+
+    def test_snap_directory(self):
+        project_dir = 'assemble'
+        self.run_snapcraft('snap', project_dir)
+        os.chdir(project_dir)
+
+        snap_file_path = 'assemble_1.0_{}.snap'.format(_get_deb_arch())
+        os.remove(snap_file_path)
+
+        # Verify that Snapcraft can snap its own snap directory (this will make
+        # sure `snapcraft snap` and `snapcraft snap <directory>` are always in
+        # sync).
+        self.run_snapcraft(['snap', 'snap'])
+        self.assertThat(snap_file_path, FileExists())
 
     def test_error_with_unexistent_build_package(self):
         project_dir = self.copy_project_to_tmp('assemble')

--- a/snapcraft/commands/snap.py
+++ b/snapcraft/commands/snap.py
@@ -45,8 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 def _snap_data_from_dir(dir):
-    # TODO: change to 'snap.yaml'
-    with open(os.path.join(dir, 'meta', 'package.yaml')) as f:
+    with open(os.path.join(dir, 'meta', 'snap.yaml')) as f:
         snap = yaml.load(f)
 
     return {'name': snap['name'],
@@ -64,8 +63,6 @@ def main(argv=None):
     args = docopt(__doc__, argv=argv)
 
     if args['DIRECTORY']:
-        # TODO: migrate to meta/snap.yaml
-        # TODO: write integration test
         snap_dir = os.path.abspath(args['DIRECTORY'])
         snap = _snap_data_from_dir(snap_dir)
     else:

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -110,7 +110,7 @@ parts:
 
         meta_dir = os.path.join('mysnap', 'meta')
         os.makedirs(meta_dir)
-        with open(os.path.join(meta_dir, 'package.yaml'), 'w') as f:
+        with open(os.path.join(meta_dir, 'snap.yaml'), 'w') as f:
             f.write("""name: my_snap
 version: 99
 architectures: [amd64, armhf]


### PR DESCRIPTION
Fixes LP: [#1541987](https://bugs.launchpad.net/snapcraft/+bug/1541987)