### PR TITLE
Upload: Obtain name from YAML instead of snap.

### DIFF
--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -54,13 +54,13 @@ def main(argv=None):
 
     # make sure the full lifecycle is executed
     yaml_config = snapcraft.yaml.load_config()
-    snap_name = _format_snap_name(yaml_config.data)
+    snap_filename = _format_snap_name(yaml_config.data)
 
-    if not os.path.exists(snap_name):
+    if not os.path.exists(snap_filename):
         logger.info(
             'Snap {} not found. Running snap step to create it.'.format(
-                snap_name))
+                snap_filename))
         snap.main(argv=argv)
 
     config = load_config()
-    upload(snap_name, config=config)
+    upload(snap_filename, yaml_config.data['name'], config=config)

--- a/snapcraft/storeapi/_upload.py
+++ b/snapcraft/storeapi/_upload.py
@@ -19,7 +19,6 @@ import logging
 import functools
 import time
 import os
-import re
 
 from concurrent.futures import ThreadPoolExecutor
 from progressbar import (ProgressBar, Percentage, Bar, AnimatedMarker)
@@ -46,18 +45,9 @@ def _update_progress_bar(progress_bar, maximum_value, monitor):
         progress_bar.update(monitor.bytes_read)
 
 
-def upload(binary_filename, metadata_filename='', metadata=None, config=None):
+def upload(binary_filename, snap_name, metadata_filename='', metadata=None,
+           config=None):
     """Create a new upload based on a snap package."""
-
-    # validate package filename
-    pattern = (r'(.*/)?(?P<name>[\w\-_\.]+)_'
-               '(?P<version>[\d\.]+)_(?P<arch>\w+)\.snap')
-    match = re.match(pattern, binary_filename)
-    if not match:
-        logger.info('Invalid package filename.')
-        return
-    name = match.groupdict()['name']
-
     # Print a newline so the progress bar has some breathing room.
     print('')
 
@@ -70,7 +60,7 @@ def upload(binary_filename, metadata_filename='', metadata=None, config=None):
 
     meta = read_metadata(metadata_filename)
     meta.update(metadata or {})
-    result = upload_app(name, data, metadata=meta, config=config)
+    result = upload_app(snap_name, data, metadata=meta, config=config)
     success = result.get('success', False)
     errors = result.get('errors', [])
     app_url = result.get('application_url', '')
@@ -91,7 +81,7 @@ def upload(binary_filename, metadata_filename='', metadata=None, config=None):
 
     if errors:
         logger.info('Some errors were detected:\n\n%s\n',
-                    '\n'.join(errors))
+                    '\n'.join(str(error) for error in errors))
 
     if app_url:
         logger.info('Please check out the application at: %s\n',

--- a/snapcraft/tests/test_commands_upload.py
+++ b/snapcraft/tests/test_commands_upload.py
@@ -97,6 +97,7 @@ parts:
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',
+            'snap-test',
             config=self.mock_load_config.return_value)
 
     def test_upload_failed(self):
@@ -129,6 +130,7 @@ parts:
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',
+            'snap-test',
             config=self.mock_load_config.return_value)
 
     def test_just_upload_if_snap_file_exists(self):
@@ -143,4 +145,5 @@ parts:
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',
+            'snap-test',
             config=self.mock_load_config.return_value)

--- a/snapcraft/tests/test_storeapi_upload.py
+++ b/snapcraft/tests/test_storeapi_upload.py
@@ -69,20 +69,10 @@ class UploadBaseTestCase(tests.TestCase):
 
 class UploadTestCase(UploadBaseTestCase):
 
-    def test_invalid_package_name(self):
-        self.suffix = '_0.1_all.img'
-        self.binary_file = self.get_temporary_file(suffix=self.suffix)
-
-        success = upload(self.binary_file.name)
-
-        self.assertIsNone(success)
-        self.mock_logger.info.assert_called_once_with(
-            'Invalid package filename.')
-
     def test_upload_files_failed(self):
         self.mock_post.side_effect = Exception('some error')
 
-        success = upload(self.binary_file.name)
+        success = upload(self.binary_file.name, 'foo')
 
         self.assertFalse(success)
         self.mock_logger.info.assert_called_once_with(
@@ -107,7 +97,7 @@ class UploadTestCase(UploadBaseTestCase):
              'application_url': application_url}).encode('utf-8')
         self.mock_get.return_value = ok_response
 
-        success = upload(self.binary_file.name)
+        success = upload(self.binary_file.name, 'foo')
 
         self.assertTrue(success)
         self.assertIn(
@@ -134,7 +124,7 @@ class UploadTestCase(UploadBaseTestCase):
             {'completed': True}).encode('utf-8')
         self.mock_get.return_value = ok_response
 
-        success = upload(self.binary_file.name)
+        success = upload(self.binary_file.name, 'foo')
 
         self.assertTrue(success)
         self.assertNotIn(
@@ -152,7 +142,7 @@ class UploadTestCase(UploadBaseTestCase):
         # file uploaded ok, application submission failed
         self.mock_post.side_effect = [mock_response, Exception('some error')]
 
-        success = upload(self.binary_file.name)
+        success = upload(self.binary_file.name, 'foo')
 
         self.assertFalse(success)
         self.assertIn(
@@ -174,16 +164,16 @@ class UploadWithScanTestCase(UploadBaseTestCase):
             'upload_id': 'some-valid-upload-id',
         }
 
-        upload(self.binary_file.name)
+        upload(self.binary_file.name, 'foo')
 
         data = {
             'updown_id': 'some-valid-upload-id',
             'source_uploaded': False,
             'binary_filesize': self.binary_file_size,
         }
-        name = os.path.basename(self.binary_file.name).replace(self.suffix, '')
+
         self.mock_post.assert_called_with(
-            get_upload_url(name), data=data, files=[])
+            get_upload_url('foo'), data=data, files=[])
 
     def test_metadata_from_file(self):
         mock_response = self.mock_post.return_value
@@ -199,7 +189,8 @@ class UploadWithScanTestCase(UploadBaseTestCase):
             metadata_file.flush()
 
             upload(
-                self.binary_file.name, metadata_filename=metadata_file.name)
+                self.binary_file.name, 'foo',
+                metadata_filename=metadata_file.name)
 
         data = {
             'updown_id': 'some-valid-upload-id',
@@ -207,9 +198,9 @@ class UploadWithScanTestCase(UploadBaseTestCase):
             'binary_filesize': self.binary_file_size,
             'name': 'from_file',
         }
-        name = os.path.basename(self.binary_file.name).replace(self.suffix, '')
+
         self.mock_post.assert_called_with(
-            get_upload_url(name), data=data, files=[])
+            get_upload_url('foo'), data=data, files=[])
 
     def test_override_metadata(self):
         mock_response = self.mock_post.return_value
@@ -220,7 +211,8 @@ class UploadWithScanTestCase(UploadBaseTestCase):
         }
 
         upload(
-            self.binary_file.name, metadata={'name': 'overridden'})
+            self.binary_file.name, 'foo',
+            metadata={'name': 'overridden'})
 
         data = {
             'updown_id': 'some-valid-upload-id',
@@ -228,9 +220,9 @@ class UploadWithScanTestCase(UploadBaseTestCase):
             'binary_filesize': self.binary_file_size,
             'name': 'overridden',
         }
-        name = os.path.basename(self.binary_file.name).replace(self.suffix, '')
+
         self.mock_post.assert_called_with(
-            get_upload_url(name), data=data, files=[])
+            get_upload_url('foo'), data=data, files=[])
 
 
 class UploadFilesTestCase(UploadBaseTestCase):


### PR DESCRIPTION
This PR fixes LP: [#1541353](https://bugs.launchpad.net/snapcraft/+bug/1541353) by using the `snapcraft.yaml` to obtain the snap name rather than using regex against the snap package, which was rather fragile and not in accordance with the spec.