### PR TITLE
Support setting an output file when snapping

### DIFF
--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -97,6 +97,18 @@ class SnapTestCase(integration_tests.TestCase):
         self.run_snapcraft(['snap', 'snap'])
         self.assertThat(snap_file_path, FileExists())
 
+    def test_snap_long_output_option(self):
+        project_dir = 'assemble'
+        self.run_snapcraft(['snap', '--output', 'mysnap.snap'], project_dir)
+        os.chdir(project_dir)
+        self.assertThat('mysnap.snap', FileExists())
+
+    def test_snap_short_output_option(self):
+        project_dir = 'assemble'
+        self.run_snapcraft(['snap', '-o', 'mysnap.snap'], project_dir)
+        os.chdir(project_dir)
+        self.assertThat('mysnap.snap', FileExists())
+
     def test_error_with_unexistent_build_package(self):
         project_dir = self.copy_project_to_tmp('assemble')
         os.chdir(project_dir)

--- a/snapcraft/commands/snap.py
+++ b/snapcraft/commands/snap.py
@@ -23,8 +23,9 @@ Usage:
   snap [options] [DIRECTORY]
 
 Options:
-  DIRECTORY             optional target directory to snap.
-  -h --help             show this help message and exit.
+  DIRECTORY               optional target directory to snap.
+  -h --help               show this help message and exit.
+  -o SNAP --output SNAP   create snap with a specific filename
 
 """
 
@@ -70,7 +71,7 @@ def main(argv=None):
         snap_dir = common.get_snapdir()
         snap = lifecycle.execute('strip')
 
-    snap_name = _format_snap_name(snap)
+    snap_name = args['--output'] or _format_snap_name(snap)
 
     logger.info('Snapping {}'.format(snap_name))
     subprocess.check_call(


### PR DESCRIPTION
This adds support for -o or --output to have a deterministic
output file for a snap.

LP: #1542479

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>