### PR TITLE
adt fixes for maven and noninteractive deb install

### DIFF
--- a/examples_tests/tests.py
+++ b/examples_tests/tests.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 import time
 
+import fixtures
 import testscenarios
 import testtools
 from testtools import content
@@ -240,6 +241,8 @@ class TestSnapcraftExamples(testscenarios.WithScenarios, testtools.TestCase):
         snapcraft_bin = os.getenv('SNAPCRAFT', 'snapcraft')
         self.snapcraft_command = os.path.join(
             os.getcwd(), 'bin', snapcraft_bin)
+        self.useFixture(
+            fixtures.EnvironmentVariable('SNAPCRAFT_SETUP_PROXIES', '1'))
 
     def run_command_through_ssh(self, command):
         try:

--- a/integration_tests/test_maven_plugin.py
+++ b/integration_tests/test_maven_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,10 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import fixtures
+
 import integration_tests
 
 
 class MavenPluginTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(
+            fixtures.EnvironmentVariable('SNAPCRAFT_SETUP_PROXIES', '1'))
 
     def test_build_maven_plugin(self):
         project_dir = 'simple-maven'

--- a/snapcraft/repo.py
+++ b/snapcraft/repo.py
@@ -72,10 +72,15 @@ def install_build_packages(packages):
     if new_packages:
         logger.info(
             'Installing build dependencies: %s', ' '.join(new_packages))
+        env = os.environ.copy()
+        env.update({
+            'DEBIAN_FRONTEND': 'noninteractive',
+            'DEBCONF_NONINTERACTIVE_SEEN': 'true',
+        })
         subprocess.check_call(['sudo', 'apt-get', '-o',
                                'Dpkg::Progress-Fancy=1',
-                               '--no-install-recommends',
-                               '-y', 'install'] + new_packages)
+                               '--no-install-recommends', '-y',
+                               'install'] + new_packages, env=env)
 
 
 class PackageNotFoundError(Exception):

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -1,0 +1,232 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from unittest import mock
+
+import fixtures
+
+from snapcraft import tests
+from snapcraft.plugins import maven
+
+
+class MavenPluginTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Options:
+            maven_options = []
+
+        self.options = Options()
+
+        patcher = mock.patch('snapcraft.repo.Ubuntu')
+        self.ubuntu_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_schema(self):
+        schema = maven.MavenPlugin.schema()
+
+        properties = schema['properties']
+        self.assertTrue('maven-options' in properties,
+                        'Expected "maven-options" to be included in '
+                        'properties')
+
+        maven_options = properties['maven-options']
+
+        self.assertTrue(
+            'type' in maven_options,
+            'Expected "type" to be included in "maven-options"')
+        self.assertEqual(maven_options['type'], 'array',
+                         'Expected "maven-options" "type" to be "array", but '
+                         'it was "{}"'.format(maven_options['type']))
+
+        self.assertTrue(
+            'minitems' in maven_options,
+            'Expected "minitems" to be included in "maven-options"')
+        self.assertEqual(maven_options['minitems'], 1,
+                         'Expected "maven-options" "minitems" to be 1, but '
+                         'it was "{}"'.format(maven_options['minitems']))
+
+        self.assertTrue(
+            'uniqueItems' in maven_options,
+            'Expected "uniqueItems" to be included in "maven-options"')
+        self.assertTrue(
+            maven_options['uniqueItems'],
+            'Expected "maven-options" "uniqueItems" to be "True"')
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build(self, glob_mock, run_mock):
+        plugin = maven.MavenPlugin('test-part', self.options)
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package']),
+        ])
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_snapcraft_proxy(self, glob_mock, run_mock):
+        env_vars = (
+            ('SNAPCRAFT_SETUP_PROXIES', '1',),
+            ('http_proxy', 'http://localhost:3132'),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
+        plugin = maven.MavenPlugin('test-part', self.options)
+
+        settings_path = os.path.join(plugin.partdir, 'm2', 'settings.xml')
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package', '-s', settings_path]),
+        ])
+
+        self.assertTrue(
+            os.path.exists(settings_path),
+            'expected {!r} to exist'.format(settings_path))
+
+        with open(settings_path) as f:
+            settings_contents = f.read()
+
+        expected_contents = (
+            '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
+            '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+            '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
+            '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
+            '  <interactiveMode>false</interactiveMode>\n'
+            '  <proxies>\n'
+            '    <proxy>\n'
+            '      <id>proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>localhost</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '  </proxies>\n'
+            '</settings>\n')
+        self.assertEqual(settings_contents, expected_contents)
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_proxy_and_no_proxy(self, glob_mock, run_mock):
+        env_vars = (
+            ('SNAPCRAFT_SETUP_PROXIES', '1',),
+            ('http_proxy', 'http://localhost:3132'),
+            ('no_proxy', 'internal'),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
+        plugin = maven.MavenPlugin('test-part', self.options)
+
+        settings_path = os.path.join(plugin.partdir, 'm2', 'settings.xml')
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package', '-s', settings_path]),
+        ])
+
+        self.assertTrue(
+            os.path.exists(settings_path),
+            'expected {!r} to exist'.format(settings_path))
+
+        with open(settings_path) as f:
+            settings_contents = f.read()
+
+        expected_contents = (
+            '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
+            '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+            '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
+            '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
+            '  <interactiveMode>false</interactiveMode>\n'
+            '  <proxies>\n'
+            '    <proxy>\n'
+            '      <id>proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>internal</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '  </proxies>\n'
+            '</settings>\n')
+        self.assertEqual(settings_contents, expected_contents)
+
+    @mock.patch.object(maven.MavenPlugin, 'run')
+    @mock.patch('glob.glob')
+    def test_build_with_proxy_and_no_proxies(self, glob_mock, run_mock):
+        env_vars = (
+            ('SNAPCRAFT_SETUP_PROXIES', '1',),
+            ('http_proxy', 'http://localhost:3132'),
+            ('no_proxy', 'internal, pseudo-dmz'),
+        )
+        for v in env_vars:
+            self.useFixture(fixtures.EnvironmentVariable(v[0], v[1]))
+
+        plugin = maven.MavenPlugin('test-part', self.options)
+
+        settings_path = os.path.join(plugin.partdir, 'm2', 'settings.xml')
+        os.makedirs(plugin.sourcedir)
+        glob_mock.return_value = [
+            os.path.join(plugin.builddir, 'target', 'dummy')]
+
+        plugin.build()
+
+        run_mock.assert_has_calls([
+            mock.call(['mvn', 'package', '-s', settings_path]),
+        ])
+
+        self.assertTrue(
+            os.path.exists(settings_path),
+            'expected {!r} to exist'.format(settings_path))
+
+        with open(settings_path) as f:
+            settings_contents = f.read()
+
+        expected_contents = (
+            '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"\n'
+            '          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+            '          xsi:schemaLocation="http://maven.apache.org/SETTINGS/'
+            '1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">\n'
+            '  <interactiveMode>false</interactiveMode>\n'
+            '  <proxies>\n'
+            '    <proxy>\n'
+            '      <id>proxy</id>\n'
+            '      <active>true</active>\n'
+            '      <protocol>http</protocol>\n'
+            '      <host>localhost</host>\n'
+            '      <port>3132</port>\n'
+            '      <nonProxyHosts>internal|pseudo-dmz</nonProxyHosts>\n'
+            '    </proxy>\n'
+            '  </proxies>\n'
+            '</settings>\n')
+        self.assertEqual(settings_contents, expected_contents)


### PR DESCRIPTION
This makes sure we setup noninteractive for deb installation and
also sets up the proxy configuration for maven.

LP: #1542511

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>