### PR TITLE
Add missing build-packages for the opencv example

### DIFF
--- a/examples/opencv/snapcraft.yaml
+++ b/examples/opencv/snapcraft.yaml
@@ -3,6 +3,8 @@ version: 1.0
 summary: Use OpenCV and OpenGL
 description: A simple OpenCV example
 
+build-packages: [gcc, g++, libc6-dev]
+
 apps:
   example:
     command: bin/example


### PR DESCRIPTION
It was missing: gcc, g++ and libc6-dev

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>