### PR TITLE
Add missing libc6 build dep to integration tests

### DIFF
--- a/integration_tests/snaps/conflicts/snapcraft.yaml
+++ b/integration_tests/snaps/conflicts/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
 
 parts:
   p1:

--- a/integration_tests/snaps/dependencies/snapcraft.yaml
+++ b/integration_tests/snaps/dependencies/snapcraft.yaml
@@ -4,7 +4,8 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
+
 parts:
   p1:
     plugin: make

--- a/integration_tests/snaps/simple-cmake/CMakeLists.txt
+++ b/integration_tests/snaps/simple-cmake/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.2)
 project(simple-cmake C)
 add_executable(simple-cmake test.c)
 install(TARGETS simple-cmake RUNTIME DESTINATION bin)

--- a/integration_tests/snaps/simple-cmake/snapcraft.yaml
+++ b/integration_tests/snaps/simple-cmake/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
 
 parts:
   cmake-project:

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
 
 parts:
   make-project:

--- a/integration_tests/snaps/simple-make/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
 
 parts:
   make-project:

--- a/integration_tests/snaps/simple-scons/snapcraft.yaml
+++ b/integration_tests/snaps/simple-scons/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: test a simple scons project
 description: a longer description
 icon: icon.png
 
-build-packages: [gcc]
+build-packages: [gcc, libc6-dev]
 
 parts:
   scons-project:

--- a/integration_tests/snaps/simple-tar/snapcraft.yaml
+++ b/integration_tests/snaps/simple-tar/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 
+build-packages: [gcc, libc6-dev]
+
 parts:
   oneflat:
     plugin: tar-content


### PR DESCRIPTION
Most integration tests were missing a build dependency of libc6-dev

LP: #1544343

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>