### PR TITLE
Adding python-minimal to plugins that need it

### DIFF
--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -16,6 +16,7 @@
 
 # Data/methods shared between plugins and snapcraft
 
+import glob
 import os
 import platform
 import subprocess
@@ -131,6 +132,17 @@ def set_schemadir(schemadir):
 
 def get_schemadir():
     return _schemadir
+
+
+def get_python2_path(root):
+    """Return a valid PYTHONPATH or raise an exception."""
+    python_paths = glob.glob(os.path.join(
+        root, 'usr', 'lib', 'python2*', 'dist-packages'))
+    try:
+        return python_paths[0]
+    except IndexError:
+        raise EnvironmentError(
+            'PYTHONPATH cannot be set for {!r}'.format(root))
 
 
 def isurl(url):

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -546,22 +546,39 @@ class CatkinPluginTestCase(tests.TestCase):
     @mock.patch.object(catkin.CatkinPlugin, 'run_output', return_value='bar')
     def test_run_environment(self, run_mock):
         plugin = catkin.CatkinPlugin('test-part', self.properties)
-        environment = plugin.env('/foo')
 
-        self.assertTrue('PYTHONPATH={}'.format(os.path.join(
-            '/foo', 'usr', 'lib', 'bar', 'dist-packages')
-            in environment))
+        python_path = os.path.join(
+            plugin.installdir, 'usr', 'lib', 'python2.7', 'dist-packages')
+        os.makedirs(python_path)
+
+        environment = plugin.env(plugin.installdir)
+
+        self.assertTrue(
+            'PYTHONPATH={}'.format(python_path) in environment, environment)
 
         self.assertTrue('ROS_MASTER_URI=http://localhost:11311' in environment)
 
         self.assertTrue('ROS_HOME=$SNAP_USER_DATA/ros' in environment)
 
         self.assertTrue('_CATKIN_SETUP_DIR={}'.format(os.path.join(
-            '/foo', 'opt', 'ros', self.properties.rosdistro)) in environment)
+            plugin.installdir, 'opt', 'ros', self.properties.rosdistro))
+            in environment)
 
-        self.assertTrue('. {}'.format('/foo', 'opt', 'ros', 'setup.sh') in
-                        '\n'.join(environment),
-                        'Expected ROS\'s setup.sh to be sourced')
+        self.assertTrue(
+            '. {}'.format(plugin.installdir, 'opt', 'ros', 'setup.sh') in
+            '\n'.join(environment), 'Expected ROS\'s setup.sh to be sourced')
+
+    @mock.patch.object(catkin.CatkinPlugin, 'run_output', return_value='bar')
+    def test_run_environment_no_python(self, run_mock):
+        plugin = catkin.CatkinPlugin('test-part', self.properties)
+
+        python_path = os.path.join(
+            plugin.installdir, 'usr', 'lib', 'python2.7', 'dist-packages')
+
+        environment = plugin.env(plugin.installdir)
+
+        self.assertFalse(
+            'PYTHONPATH={}'.format(python_path) in environment, environment)
 
 
 class FindSystemDependenciesTestCase(tests.TestCase):

--- a/snapcraft/tests/test_plugin_python2.py
+++ b/snapcraft/tests/test_plugin_python2.py
@@ -40,8 +40,10 @@ class Python2PluginTestCase(tests.TestCase):
                                                 run_mock):
         plugin = python2.Python2Plugin('test-part', self.options)
         os.makedirs(plugin.sourcedir)
-        os.makedirs(os.path.join(plugin.installdir, 'usr', 'lib', 'python2.7',
-                                 'dist-packages'))
+        os.makedirs(os.path.join(
+            plugin.installdir, 'usr', 'lib', 'python2.7', 'dist-packages'))
+        os.makedirs(os.path.join(
+            plugin.installdir, 'usr', 'include', 'python2.7'))
 
         open(os.path.join(plugin.sourcedir, 'setup.py'), 'w').close()
 
@@ -53,3 +55,9 @@ class Python2PluginTestCase(tests.TestCase):
                          'Expected site-packages to be a relative link to '
                          '"dist-packages", but it was a link to "{}"'
                          .format(link))
+
+    def test_get_python2_include_missing_raises_exception(self):
+        with self.assertRaises(EnvironmentError) as raised:
+            python2._get_python2_include('/foo')
+        self.assertEqual(str(raised.exception),
+                         'python development headers not installed')


### PR DESCRIPTION
python-minimal is needed by the python2 and the catkin plugin.

LP: #1541451

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>