### PR TITLE
Set after test cmake project to use no language

### DIFF
--- a/integration_tests/snaps/stage_env/CMakeLists.txt
+++ b/integration_tests/snaps/stage_env/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(simple-cmake)
+project(simple-cmake NONE)
 
 IF(NOT DEFINED DEP_DIR)
     message(FATAL_ERROR "DEP_DIR is not defined.")


### PR DESCRIPTION
The after integration test had a cmake project set to use
the generic language template, as this cmake project does
nothing we explicitly set it to NONE.

LP: #1544792

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>