### PR TITLE
Catkin plugin: Print nice message if dependency is invalid.

### DIFF
--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -207,7 +207,12 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
             ubuntu = repo.Ubuntu(ubuntudir, sources=self.PLUGIN_STAGE_SOURCES)
 
             logger.info('Fetching package dependencies...')
-            ubuntu.get(system_dependencies)
+            try:
+                ubuntu.get(system_dependencies)
+            except repo.PackageNotFoundError as e:
+                raise RuntimeError(
+                    'Failed to fetch system dependencies: {}'.format(
+                        e.message))
 
             logger.info('Installing package dependencies...')
             ubuntu.unpack(self.installdir)


### PR DESCRIPTION
This PR fixes LP: [#1548370](https://bugs.launchpad.net/snapcraft/+bug/1548370) by catching the relevant exception raised by `repo.Ubuntu` and printing a message explaining exactly what the problem was.