### PR TITLE
Support --debug flag to enable backtrace and debug logs.

### DIFF
--- a/snapcraft/log.py
+++ b/snapcraft/log.py
@@ -37,7 +37,10 @@ class _StderrFilter(logging.Filter):
         return record.levelno >= logging.ERROR
 
 
-def configure(logger_name=None):
+def configure(logger_name=None, log_level=None):
+    if not log_level:
+        log_level = logging.INFO
+
     if not os.isatty(1) and not sys.stdout.line_buffering:
         # Line buffering makes logs easier to handle.
         sys.stdout.flush()
@@ -64,7 +67,7 @@ def configure(logger_name=None):
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
 
     # INFO from the requests lib is too noisy
     logging.getLogger("requests").setLevel(logging.WARNING)

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -26,6 +26,8 @@ Options:
   -h --help        show this help message and exit
   -v --version     show program version and exit
   -V --verbose     print additional information about command execution
+  -d --debug       print debug information while executing (including
+                   backtraces)
 
 The available commands are:
   list-parts   List available parts which are like “source packages” for snaps.
@@ -95,16 +97,25 @@ def _get_version():
 
 
 def main():
-    log.configure()
     args = docopt(__doc__, version=_get_version(), options_first=True)
 
     cmd = args['COMMAND'] or 'snap'
     if cmd not in _VALID_COMMANDS:
         sys.exit('Command {!r} was not recognized'.format(cmd))
 
+    # Default log level is INFO unless --debug is specified
+    log_level = logging.INFO
+    if args['--debug']:
+        log_level = logging.DEBUG
+
+    log.configure(log_level=log_level)
+
     try:
         commands.load(cmd).main(argv=args['ARGS'])
     except Exception as e:
+        if args['--debug']:
+            raise
+
         sys.exit(textwrap.fill(str(e)))
 
 

--- a/snapcraft/tests/test_log.py
+++ b/snapcraft/tests/test_log.py
@@ -85,3 +85,25 @@ class LogTestCase(tests.TestCase):
             '\033[1mTest critical\033[0m\n')
         self.assertEqual(expected_out, mock_stdout.getvalue())
         self.assertEqual(expected_err, mock_stderr.getvalue())
+
+    def test_configure_must_support_debug(
+            self, mock_stderr, mock_stdout, mock_isatty):
+        logger_name = self.id()
+        log.configure(logger_name, log_level=logging.DEBUG)
+        logger = logging.getLogger(logger_name)
+
+        logger.debug('Test debug')
+        logger.info('Test info')
+        logger.warning('Test warning')
+        logger.error('Test error')
+        logger.critical('Test critical')
+
+        expected_out = (
+            '\033[1mTest debug\033[0m\n'
+            '\033[1mTest info\033[0m\n'
+            '\033[1mTest warning\033[0m\n')
+        expected_err = (
+            '\033[1mTest error\033[0m\n'
+            '\033[1mTest critical\033[0m\n')
+        self.assertEqual(expected_out, mock_stdout.getvalue())
+        self.assertEqual(expected_err, mock_stderr.getvalue())


### PR DESCRIPTION
This PR resolves LP: [#1548492](https://bugs.launchpad.net/snapcraft/+bug/1548492) by re-raising any caught exception and changing the log level to DEBUG if Snapcraft is running with the `-d` or `--debug` argument.