### PR TITLE
Calling snapcraft with no args defaults to snap

### DIFF
--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -75,6 +75,14 @@ class SnapTestCase(integration_tests.TestCase):
             os.path.join('snap', 'bin', 'not-wrapped.wrapper'),
             Not(FileExists()))
 
+    def test_snap_default(self):
+        project_dir = 'assemble'
+        self.run_snapcraft([], project_dir)
+        os.chdir(project_dir)
+
+        snap_file_path = 'assemble_1.0_{}.snap'.format(get_arch())
+        self.assertThat(snap_file_path, FileExists())
+
     def test_cleanbuild(self):
         self.skipTest("Fails to run correctly on travis.")
         project_dir = 'assemble'

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -20,6 +20,7 @@ snapcraft
 
 Usage:
   snapcraft [--version | --help] [options] COMMAND [ARGS ...]
+  snapcraft [options]
 
 Options:
   -h --help        show this help message and exit
@@ -47,11 +48,13 @@ The available lifecycle commands are:
   upload       Upload a snap to the Ubuntu Store.
 
 See 'snapcraft COMMAND --help' for more information on a specific command.
+Calling snapcraft without a COMMAND will default to 'snap'
 
 For more help, visit the documentation:
 http://developer.ubuntu.com/snappy/snapcraft
 """
 
+import logging
 import pkg_resources
 import sys
 import textwrap
@@ -62,6 +65,8 @@ from snapcraft import (
     log,
     commands,
 )
+
+logger = logging.getLogger(__name__)
 
 _VALID_COMMANDS = [
     'list-parts',
@@ -81,25 +86,27 @@ _VALID_COMMANDS = [
     'upload',
 ]
 
-try:
-    version = pkg_resources.require('snapcraft')[0].version
-except pkg_resources.DistributionNotFound:
-    version = 'devel'
+
+def _get_version():
+    try:
+        return pkg_resources.require('snapcraft')[0].version
+    except pkg_resources.DistributionNotFound:
+        return 'devel'
 
 
 def main():
     log.configure()
-    args = docopt(__doc__,
-                  version=version,
-                  options_first=True)
-    if args['COMMAND'] not in _VALID_COMMANDS:
-        sys.exit('Command {!r} was not recognized'.format(args['COMMAND']))
+    args = docopt(__doc__, version=_get_version(), options_first=True)
+
+    cmd = args['COMMAND'] or 'snap'
+    if cmd not in _VALID_COMMANDS:
+        sys.exit('Command {!r} was not recognized'.format(cmd))
 
     try:
-        commands.load(args['COMMAND']).main(argv=args['ARGS'])
+        commands.load(cmd).main(argv=args['ARGS'])
     except Exception as e:
         sys.exit(textwrap.fill(str(e)))
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == '__main__':  # pragma: no cover
+    main()                  # pragma: no cover

--- a/snapcraft/tests/test_main.py
+++ b/snapcraft/tests/test_main.py
@@ -14,7 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import mock
+import pkg_resources
+import sys
 
 import snapcraft.main
 
@@ -22,13 +25,6 @@ from snapcraft.tests import TestCase
 
 
 class TestMain(TestCase):
-
-    def setUp(self):
-        super(TestMain, self).setUp()
-
-        patcher = mock.patch('snapcraft.main.docopt')
-        self.mock_docopt = patcher.start()
-        self.addCleanup(patcher.stop)
 
     def test_valid_commands(self):
         expected = [
@@ -50,8 +46,9 @@ class TestMain(TestCase):
         ]
         self.assertEqual(snapcraft.main._VALID_COMMANDS, expected)
 
-    def test_invalid_command(self):
-        self.mock_docopt.return_value = {
+    @mock.patch('snapcraft.main.docopt')
+    def test_invalid_command(self, mock_docopt):
+        mock_docopt.return_value = {
             'COMMAND': 'invalid',
             'ARGS': [],
         }
@@ -61,8 +58,19 @@ class TestMain(TestCase):
         self.assertEqual(
             str(cm.exception), "Command 'invalid' was not recognized")
 
-    def test_command_error(self):
-        self.mock_docopt.return_value = {
+    @mock.patch('snapcraft.main.docopt')
+    def test_default_command_is_snap(self, mock_docopt):
+        mock_docopt.return_value = {
+            'COMMAND': '',
+            'ARGS': [],
+        }
+        with mock.patch('snapcraft.commands.snap.main') as mock_cmd:
+            snapcraft.main.main()
+            mock_cmd.assert_called_once_with(argv=[])
+
+    @mock.patch('snapcraft.main.docopt')
+    def test_command_error(self, mock_docopt):
+        mock_docopt.return_value = {
             'COMMAND': 'help',
             'ARGS': [],
         }
@@ -73,3 +81,14 @@ class TestMain(TestCase):
                 snapcraft.main.main()
 
         self.assertEqual(str(cm.exception), 'some error')
+
+    @mock.patch('pkg_resources.require')
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    def test_devel_version(self, mock_stdout, mock_resources):
+        mock_resources.side_effect = pkg_resources.DistributionNotFound()
+        sys.argv = ['/usr/bin/snapcraft', '--version']
+
+        with self.assertRaises(SystemExit):
+            snapcraft.main.main()
+
+        self.assertEqual(mock_stdout.getvalue(), 'devel\n')


### PR DESCRIPTION
Calling snapcraft with no arguments should default to just calling
the `snap` command for easier use.

LP: #1548915

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>