### PR TITLE
More attributes for the squashfs'ed snap

### DIFF
--- a/snapcraft/commands/snap.py
+++ b/snapcraft/commands/snap.py
@@ -74,6 +74,9 @@ def main(argv=None):
     snap_name = args['--output'] or _format_snap_name(snap)
 
     logger.info('Snapping {}'.format(snap_name))
+    # These options need to match the review tools:
+    # http://bazaar.launchpad.net/~click-reviewers/click-reviewers-tools/trunk/view/head:/clickreviews/common.py#L38
+    mksquashfs_args = ['-noappend', '-comp', 'xz', '-all-root', '-no-xattrs']
     subprocess.check_call(
-        ['mksquashfs', snap_dir, snap_name, '-noappend', '-comp', 'xz'])
+        ['mksquashfs', snap_dir, snap_name] + mksquashfs_args)
     logger.info('Snapped {}'.format(snap_name))

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -76,7 +76,7 @@ parts:
 
         mock_call.assert_called_once_with([
             'mksquashfs', common.get_snapdir(), 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz'])
+            '-noappend', '-comp', 'xz', '-all-root', '-no-xattrs'])
 
     @mock.patch('subprocess.check_call')
     def test_snap_defaults_with_parts_in_strip(self, mock_call):
@@ -101,7 +101,7 @@ parts:
 
         mock_call.assert_called_once_with([
             'mksquashfs', common.get_snapdir(), 'snap-test_1.0_amd64.snap',
-            '-noappend', '-comp', 'xz'])
+            '-noappend', '-comp', 'xz', '-all-root', '-no-xattrs'])
 
     @mock.patch('subprocess.check_call')
     def test_snap_from_dir(self, mock_call):
@@ -125,7 +125,7 @@ architectures: [amd64, armhf]
 
         mock_call.assert_called_once_with([
             'mksquashfs', os.path.abspath('mysnap'), 'my_snap_99_multi.snap',
-            '-noappend', '-comp', 'xz'])
+            '-noappend', '-comp', 'xz', '-all-root', '-no-xattrs'])
 
     @mock.patch('subprocess.check_call')
     def test_snap_with_output(self, mock_call):
@@ -158,4 +158,4 @@ architectures: [amd64, armhf]
 
         mock_call.assert_called_once_with([
             'mksquashfs', common.get_snapdir(), 'mysnap.snap',
-            '-noappend', '-comp', 'xz'])
+            '-noappend', '-comp', 'xz', '-all-root', '-no-xattrs'])


### PR DESCRIPTION
To make security better and easier to recreate snaps
we need to add -all-root, we also add -no-xattrs since
it is also an improvement that helps in preventing
people trying to circumvent the system.

LP: #1546821

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>