### PR TITLE
examples_tests/libpipeline: skip the output assertion when skipping the install

### DIFF
--- a/examples_tests/__init__.py
+++ b/examples_tests/__init__.py
@@ -157,11 +157,12 @@ class ExampleTestCase(testtools.TestCase):
                 '.*')
             self.assertThat(output, MatchesRegex(expected, flags=re.DOTALL))
 
-    def run_command_in_snappy_testbed(self, command):
+    def assert_command_in_snappy_testbed(self, command, expected_output):
         if not config.get('skip-install', False):
             try:
-                return self.snappy_testbed.run_command(command)
+                output = self.snappy_testbed.run_command(command)
             except subprocess.CalledProcessError as e:
                 self.addDetail(
                     'ssh output', content.text_content(str(e.output)))
                 raise
+            self.assertEqual(output, expected_output)

--- a/examples_tests/test_libpipeline.py
+++ b/examples_tests/test_libpipeline.py
@@ -24,11 +24,10 @@ class LibPipelineTestCase(examples_tests.ExampleTestCase):
     def test_libpipeline(self):
         self.build_snap(self.example_dir)
         self.install_snap(self.example_dir, 'pipelinetest', '1.0')
-        output = self.run_command_in_snappy_testbed(
-            '/snaps/bin/pipelinetest.pipelinetest')
         expected = (
             'running ls | grep c\n'
             'custom libpipeline called\n'
             'command-pipelinetest.wrapper\n'
             'include\n')
-        self.assertEqual(output, expected)
+        self.assert_command_in_snappy_testbed(
+            '/snaps/bin/pipelinetest.pipelinetest', expected)


### PR DESCRIPTION


LP: #1550108