### PR TITLE
Skip the BasePlugin from plugin search

### DIFF
--- a/integration_tests/snaps/local-plugin/parts/plugins/x_local_plugin.py
+++ b/integration_tests/snaps/local-plugin/parts/plugins/x_local_plugin.py
@@ -14,9 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import snapcraft
+from snapcraft import BasePlugin
 
 
-class LocalPlugin(snapcraft.BasePlugin):
+class LocalPlugin(BasePlugin):
     def build(self):
         return self.run(['touch', 'build-stamp'], self.installdir)

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -273,8 +273,13 @@ def _expand_env(attr):
 
 def _get_plugin(module):
     for attr in vars(module).values():
-        if isinstance(attr, type) and issubclass(attr, snapcraft.BasePlugin):
-            return attr
+        if not isinstance(attr, type):
+            continue
+        if not issubclass(attr, snapcraft.BasePlugin):
+            continue
+        if attr == snapcraft.BasePlugin:
+            continue
+        return attr
 
 
 def _load_local(module_name):


### PR DESCRIPTION
This is to support the case of a plugin importing baseplugin
as a symbol instead of the module.

LP: #1547681

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>