### PR TITLE
Expose the invalid build-package on error

### DIFF
--- a/integration_tests/test_snap.py
+++ b/integration_tests/test_snap.py
@@ -131,8 +131,8 @@ class SnapTestCase(integration_tests.TestCase):
         exception = self.assertRaises(
             subprocess.CalledProcessError, self.run_snapcraft, 'snap')
         expected = (
-            'Could not find all the "build-packages" required in '
-            'snapcraft.yaml\n')
+            "Could not find a required package in 'build-packages': "
+            '"The cache has\nno package named \'inexistent-package\'"\n')
         self.assertEqual(expected, exception.output)
 
     def test_snap_with_exposed_files(self):

--- a/snapcraft/repo.py
+++ b/snapcraft/repo.py
@@ -26,7 +26,6 @@ import stat
 import subprocess
 import urllib
 import urllib.request
-import sys
 
 import apt
 from xml.etree import ElementTree
@@ -75,10 +74,10 @@ def install_build_packages(packages):
             try:
                 if not apt_cache[pkg].installed:
                     new_packages.append(pkg)
-            except KeyError:
-                logger.error('Could not find all the "build-packages" '
-                             'required in snapcraft.yaml')
-                sys.exit(1)
+            except KeyError as e:
+                raise EnvironmentError(
+                    "Could not find a required package in "
+                    "'build-packages': {}".format(str(e)))
     if new_packages:
         logger.info(
             'Installing build dependencies: %s', ' '.join(new_packages))

--- a/snapcraft/tests/test_repo.py
+++ b/snapcraft/tests/test_repo.py
@@ -156,3 +156,15 @@ deb http://ports.ubuntu.com/ubuntu-ports trusty-security multiverse
 
                 with open(f['path'], 'r') as fd:
                     self.assertEqual(fd.read(), f['expected'])
+
+
+class BuildPackagesTestCase(tests.TestCase):
+
+    def test_invalid_package_requested(self):
+        with self.assertRaises(EnvironmentError) as raised:
+            repo.install_build_packages(['package-does-not-exist'])
+
+        self.assertEqual(
+            "Could not find a required package in 'build-packages': "
+            '"The cache has no package named \'package-does-not-exist\'"',
+            str(raised.exception))


### PR DESCRIPTION
The error that results from using an invalid build-package
is not very specific. This exposes the KeyError raised by apt.

LP: #1547672

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>