### PR TITLE
Migrate from skills to interfaces

### DIFF
--- a/examples/gopaste/snapcraft.yaml
+++ b/examples/gopaste/snapcraft.yaml
@@ -8,12 +8,11 @@ apps:
   gopaste:
     command: bin/gopaste
     daemon: simple
-    uses:
-      - gopaste-permissions
+    slots:
+      - old-security
 
-uses:
-  gopaste-permissions:
-    type: migration-skill
+slots:
+  old-security:
     caps:
       - network-listener
       - network-service

--- a/examples/mosquitto/snapcraft.yaml
+++ b/examples/mosquitto/snapcraft.yaml
@@ -7,20 +7,20 @@ apps:
   mosquitto:
     command: usr/sbin/mosquitto -c $SNAP/mosquitto.conf
     daemon: simple
-    uses: [listener-service]
+    slots: [listener-service]
   subscribe:
     command: bin/subscribe
-    uses: [listener-service]
+    slots: [listener]
   publish:
     command: bin/publish
-    uses: [listener-service]
+    slots: [listener]
 
-uses:
+slots:
   listener:
-    type: migration-skill
+    type: old-security
     caps: [network-listener]
   listener-service:
-    type: migration-skill
+    type: old-security
     caps: [network-listener, network-service]
     security-override:
       read-paths:

--- a/examples/ros/snapcraft.yaml
+++ b/examples/ros/snapcraft.yaml
@@ -6,11 +6,11 @@ description: Contains talker/listener ROS packages and a .launch file.
 apps:
   launch-project:
     command: roslaunch listener talk_and_listen.launch
-    uses: [listener]
+    slots: [listener]
 
-uses:
+slots:
   listener:
-    type: migration-skill
+    type: old-security
     caps: [network-listener]
 
 parts:

--- a/examples/shout/snapcraft.yaml
+++ b/examples/shout/snapcraft.yaml
@@ -8,11 +8,11 @@ apps:
   server:
     command: bin/shout --home $SNAP_DATA
     daemon: simple
-    uses: [listener]
+    slots: [listener]
 
-uses:
+slots:
   listener:
-    type: migration-skill
+    type: old-security
     caps: [network-listener]
 
 parts:

--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -10,11 +10,11 @@ apps:
  tomcat:
    command: bin/wrapper
    daemon: simple
-   uses: [listener-service]
+   slots: [listener-service]
 
-uses:
+slots:
   listener-service:
-    type: migration-skill
+    type: old-security
     caps: [network-listener, network-service]
 
 parts:

--- a/examples/webcam-webui/snapcraft.yaml
+++ b/examples/webcam-webui/snapcraft.yaml
@@ -9,11 +9,11 @@ apps:
   webcam-webui:
     command: bin/webcam-webui
     daemon: simple
-    uses: [listener]
+    slots: [listener]
 
-uses:
+slots:
   listener:
-    type: migration-skill
+    type: old-security
     caps: [network-listener]
 
 parts:

--- a/examples/webchat/snapcraft.yaml
+++ b/examples/webchat/snapcraft.yaml
@@ -8,11 +8,11 @@ apps:
   webchat:
     command: bin/webchat-for-a-snap
     daemon: simple
-    uses: [listener]
+    slots: [listener]
 
-uses:
+slots:
   listener:
-    type: migration-skill
+    type: old-security
     caps: [network-listener]
 
 parts:

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -54,14 +54,14 @@ definitions:
   security-template:
       type: string
       description: alternate security template to use instead of default.
-  migration-skill:
+  old-security:
     type: object
     additionalProperties: false
     properties:
         type:
           type: string
           enum:
-            - migration-skill
+            - old-security
         security-policy:
           $ref: "#definitions/security-policy"
         security-override:
@@ -168,13 +168,13 @@ properties:
             enum:
               - simple
               - forking
-          uses:
+          slots:
             type: array
             minitems: 1
             uniqueItems: true
             items:
               type: string
-          offers:
+          plugs:
             type: array
             minitems: 1
             uniqueItems: true
@@ -237,13 +237,13 @@ properties:
             items:
               type: string
             default: ['*']
-  uses:
+  slots:
     type: object
     additionalProperties: false
     patternProperties:
       ^(?!plugins$)[a-z0-9][a-z0-9+-]*$:
         oneOf:
-          - $ref: "#definitions/migration-skill"
+          - $ref: "#definitions/old-security"
   offers:
   # TODO: We have no real use case for this now, but when the snappy
   # functionality comes we don't want to block people from experimenting

--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -40,11 +40,11 @@ _MANDATORY_PACKAGE_KEYS = [
 
 _OPTIONAL_PACKAGE_KEYS = [
     'architectures',
-    'offers',
     'type',
     'license-agreement',
     'license-version',
-    'uses',
+    'plugs',
+    'slots',
 ]
 
 _OPTIONAL_HOOKS = [


### PR DESCRIPTION
This adds some sort of transparent migration logic from "skills" related
keywords to the ones belonging to "interfaces".

LP: #1549427

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>