### PR TITLE
Support parallel builds (enabled by default).

### DIFF
--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -23,11 +23,14 @@ Usage:
   snapcraft [options]
 
 Options:
-  -h --help        show this help message and exit
-  -v --version     show program version and exit
-  -V --verbose     print additional information about command execution
-  -d --debug       print debug information while executing (including
-                   backtraces)
+  -h --help              show this help message and exit
+  -v --version           show program version and exit
+  -V --verbose           print additional information about command execution
+  -d --debug             print debug information while executing (including
+                         backtraces)
+  --no-parallel-build    use only a single build job per part (the default
+                         number of jobs per part is equal to the number of
+                         CPUs)
 
 The available commands are:
   list-parts   List available parts which are like “source packages” for snaps.
@@ -43,7 +46,9 @@ The available lifecycle commands are:
   clean        Remove content - cleans downloads, builds or install artifacts.
   cleanbuild   Create a snap using a clean environment managed by lxd.
   pull         Download or retrieve artifacts defined for a part.
-  build        Build artifacts defined for a part.
+  build        Build artifacts defined for a part. Build systems capable of
+               running parallel build jobs will do so unless
+               --no-parallel-build is specified.
   stage        Stage the part's built artifacts into the common staging area.
   strip        Final copy and preparation for the snap.
   snap         Create a snap.
@@ -66,6 +71,7 @@ from docopt import docopt
 from snapcraft import (
     log,
     commands,
+    common,
 )
 
 logger = logging.getLogger(__name__)
@@ -109,6 +115,8 @@ def main():
         log_level = logging.DEBUG
 
     log.configure(log_level=log_level)
+
+    common.set_enable_parallel_builds(not args['--no-parallel-build'])
 
     try:
         commands.load(cmd).main(argv=args['ARGS'])

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -42,6 +42,7 @@ import os
 import stat
 
 import snapcraft
+import snapcraft.common
 
 
 class AutotoolsPlugin(snapcraft.BasePlugin):
@@ -111,5 +112,6 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
             configure_command.append('--prefix=' + self.installdir)
 
         self.run(configure_command + self.options.configflags)
-        self.run(['make'])
+        self.run(['make', '-j{}'.format(
+            snapcraft.common.get_parallel_build_count())])
         self.run(make_install_command)

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -69,10 +69,15 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
         else:
             sourcedir = self.sourcedir
 
+        env = self._build_environment()
+
         self.run(['cmake', sourcedir, '-DCMAKE_INSTALL_PREFIX='] +
-                 self.options.configflags, env=self._build_environment())
-        self.run(['make', 'install', 'DESTDIR=' + self.installdir],
-                 env=self._build_environment())
+                 self.options.configflags, env=env)
+
+        self.run(['make', '-j{}'.format(common.get_parallel_build_count())],
+                 env=env)
+
+        self.run(['make', 'install', 'DESTDIR=' + self.installdir], env=env)
 
     def _build_environment(self):
         env = os.environ.copy()

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -31,6 +31,7 @@ Additionally, this plugin uses the following plugin-specific keyword:
 """
 
 import snapcraft
+import snapcraft.common
 
 
 class MakePlugin(snapcraft.BasePlugin):
@@ -56,5 +57,6 @@ class MakePlugin(snapcraft.BasePlugin):
         if self.options.makefile:
             command.extend(['-f', self.options.makefile])
 
-        self.run(command)
+        self.run(command + ['-j{}'.format(
+            snapcraft.common.get_parallel_build_count())])
         self.run(command + ['install', 'DESTDIR=' + self.installdir])

--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -49,6 +49,8 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
         self.addCleanup(common.set_plugindir, common.get_plugindir())
         self.addCleanup(common.set_schemadir, common.get_schemadir())
         self.addCleanup(common.set_schemadir, common.get_schemadir())
+        self.addCleanup(common.set_enable_parallel_builds,
+                        common.get_enable_parallel_builds())
         self.addCleanup(common.reset_env)
         common.set_schemadir(os.path.join(__file__,
                              '..', '..', '..', 'schema'))

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -91,6 +91,22 @@ class CommonTestCase(tests.TestCase):
                 with open(file_info['path'], 'r') as f:
                     self.assertEqual(f.read(), file_info['expected'])
 
+    @patch('multiprocessing.cpu_count')
+    def test_get_parallel_build_count(self, mock_cpu_count):
+        mock_cpu_count.return_value = 3
+        self.assertEqual(common.get_parallel_build_count(), 3)
+
+    @patch('multiprocessing.cpu_count')
+    def test_get_parallel_build_count_disabled(self, mock_cpu_count):
+        common.set_enable_parallel_builds(False)
+        mock_cpu_count.return_value = 3
+        self.assertEqual(common.get_parallel_build_count(), 1)
+
+    @patch('multiprocessing.cpu_count')
+    def test_get_parallel_build_count_handle_exception(self, mock_cpu_count):
+        mock_cpu_count.side_effect = NotImplementedError
+        self.assertEqual(common.get_parallel_build_count(), 1)
+
 
 class ArchTestCase(testtools.TestCase):
 

--- a/snapcraft/tests/test_main.py
+++ b/snapcraft/tests/test_main.py
@@ -21,6 +21,7 @@ import pkg_resources
 import sys
 
 import snapcraft.main
+import snapcraft.common
 
 from snapcraft.tests import TestCase
 
@@ -52,6 +53,7 @@ class TestMain(TestCase):
         mock_docopt.return_value = {
             'COMMAND': 'invalid',
             '--debug': False,
+            '--no-parallel-build': False,
             'ARGS': [],
         }
 
@@ -65,6 +67,7 @@ class TestMain(TestCase):
         mock_docopt.return_value = {
             'COMMAND': '',
             '--debug': False,
+            '--no-parallel-build': False,
             'ARGS': [],
         }
         with mock.patch('snapcraft.commands.snap.main') as mock_cmd:
@@ -77,6 +80,7 @@ class TestMain(TestCase):
         mock_docopt.return_value = {
             'COMMAND': 'help',
             '--debug': False,
+            '--no-parallel-build': False,
             'ARGS': [],
         }
 
@@ -95,6 +99,7 @@ class TestMain(TestCase):
         mock_docopt.return_value = {
             'COMMAND': 'help',
             '--debug': True,
+            '--no-parallel-build': False,
             'ARGS': [],
         }
 
@@ -110,6 +115,38 @@ class TestMain(TestCase):
         self.assertEqual(str(cm.exception), 'some error')
         mock_log_configure.assert_called_once_with(
             log_level=logging.DEBUG)
+
+    @mock.patch('snapcraft.main.docopt')
+    def test_command_parallel_build(self, mock_docopt):
+        mock_docopt.return_value = {
+            'COMMAND': 'help',
+            '--debug': False,
+            '--no-parallel-build': False,
+            'ARGS': [],
+        }
+
+        self.assertTrue(snapcraft.common.get_enable_parallel_builds())
+
+        with mock.patch('snapcraft.commands.help.main'):
+            snapcraft.main.main()
+
+        self.assertTrue(snapcraft.common.get_enable_parallel_builds())
+
+    @mock.patch('snapcraft.main.docopt')
+    def test_command_disable_parallel_build(self, mock_docopt):
+        mock_docopt.return_value = {
+            'COMMAND': 'help',
+            '--debug': False,
+            '--no-parallel-build': True,
+            'ARGS': [],
+        }
+
+        self.assertTrue(snapcraft.common.get_enable_parallel_builds())
+
+        with mock.patch('snapcraft.commands.help.main'):
+            snapcraft.main.main()
+
+        self.assertFalse(snapcraft.common.get_enable_parallel_builds())
 
     @mock.patch('pkg_resources.require')
     @mock.patch('sys.stdout', new_callable=io.StringIO)

--- a/snapcraft/tests/test_plugin_autotools.py
+++ b/snapcraft/tests/test_plugin_autotools.py
@@ -38,6 +38,11 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch('snapcraft.common.get_parallel_build_count')
+        self.get_parallel_build_count_mock = patcher.start()
+        self.get_parallel_build_count_mock.return_value = 2
+        self.addCleanup(patcher.stop)
+
     def test_schema(self):
         schema = autotools.AutotoolsPlugin.schema()
 
@@ -124,10 +129,12 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_configure_with_destdir(self, run_mock):
         plugin = self.build_with_configure()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(3, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -137,11 +144,13 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_configure()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(3, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install'])
         ])
 
@@ -162,11 +171,13 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_autogen_with_destdir(self, run_mock):
         plugin = self.build_with_autogen()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -176,12 +187,14 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_autogen()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['env', 'NOCONFIGURE=1', './autogen.sh']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install'])
         ])
 
@@ -199,11 +212,13 @@ class AutotoolsPluginTestCase(tests.TestCase):
     def test_build_autoreconf_with_destdir(self, run_mock):
         plugin = self.build_with_autoreconf()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix=']),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -213,12 +228,14 @@ class AutotoolsPluginTestCase(tests.TestCase):
         self.options.install_via = 'prefix'
         plugin = self.build_with_autoreconf()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(4, run_mock.call_count)
         run_mock.assert_has_calls([
             mock.call(['autoreconf', '-i']),
             mock.call(['./configure', '--prefix={}'.format(
                 plugin.installdir)]),
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install'])
         ])
 

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -36,6 +36,11 @@ class MakePluginTestCase(tests.TestCase):
         self.ubuntu_mock = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = mock.patch('snapcraft.common.get_parallel_build_count')
+        self.get_parallel_build_count_mock = patcher.start()
+        self.get_parallel_build_count_mock.return_value = 2
+        self.addCleanup(patcher.stop)
+
     def test_schema(self):
         schema = make.MakePlugin.schema()
 
@@ -59,9 +64,11 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make']),
+            mock.call(['make', '-j2']),
             mock.call(['make', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])
@@ -74,9 +81,11 @@ class MakePluginTestCase(tests.TestCase):
 
         plugin.build()
 
+        self.get_parallel_build_count_mock.assert_called_with()
+
         self.assertEqual(2, run_mock.call_count)
         run_mock.assert_has_calls([
-            mock.call(['make', '-f', 'makefile.linux']),
+            mock.call(['make', '-f', 'makefile.linux', '-j2']),
             mock.call(['make', '-f', 'makefile.linux', 'install',
                        'DESTDIR={}'.format(plugin.installdir)])
         ])


### PR DESCRIPTION
Several plugins within Snapcraft support parallel builds, but Snapcraft currently doesn't take advantage of this and builds them with a single job. This PR resolves LP: [#1551417](https://bugs.launchpad.net/snapcraft/+bug/1551417) by adding support for parallel builds, and enabling them by default in the autotools, cmake, and make plugins. It also adds an option to disable parallel builds via the `--no-parallel-build` option for the case of running in a RAM-limited environment.