### PR TITLE
Do not print which's output to stdout

### DIFF
--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -228,7 +228,8 @@ def _find_bin(binary, basedir):
         tempf.write(script)
         tempf.flush()
         try:
-            common.run(['/bin/sh', tempf.name], cwd=basedir)
+            common.run(['/bin/sh', tempf.name], cwd=basedir,
+                       stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             raise CommandError(binary)
 


### PR DESCRIPTION
This will print to stderr if there is a reason to, but that is a good thing.

LP: #1551939

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>