### PR TITLE
Remove the useles decode done in tests.

### DIFF
--- a/examples_tests/__init__.py
+++ b/examples_tests/__init__.py
@@ -126,7 +126,7 @@ class ExampleTestCase(testtools.TestCase):
         try:
             subprocess.check_output(
                 [self.snapcraft_command, 'snap'], cwd=working_dir,
-                stderr=subprocess.STDOUT).decode('utf-8')
+                stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.addDetail('output', content.text_content(str(e.output)))
             raise


### PR DESCRIPTION
The examples tests shell out and capture output but this output
is not used so we should not decode it.

LP: #1552403

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>