### PR TITLE
examples_tests: update the expected result of the libpipeline test

### DIFF
--- a/examples/libpipeline/snapcraft.yaml
+++ b/examples/libpipeline/snapcraft.yaml
@@ -1,17 +1,19 @@
 name: pipelinetest
 version: 1.0
 summary: Libpipeline example
-description: this is an example package of an autotools project built with snapcraft using
+description: |
+  This is an example package of an autotools project built with snapcraft
+  using a remote source.
 icon: icon.png
 
 apps:
   pipelinetest:
-    command: ./bin/pipelinetest
+    command: ./bin/test
 
 parts:
     pipelinetest:
         plugin: make
-        source: lp:~mterry/+junk/pipelinetest
+        source: .
         after:
             - libpipeline
     libpipeline:

--- a/examples/libpipeline/test.c
+++ b/examples/libpipeline/test.c
@@ -6,10 +6,10 @@ int main()
     pipeline *p;
     int status;
 
-    printf("running ls | grep s | grep t\n");
+    printf("running echo test | grep s | grep t\n");
 
     p = pipeline_new ();
-    pipeline_command_args (p, "ls", NULL);
+    pipeline_command_args (p, "echo", "test", NULL);
     pipeline_command_args (p, "grep", "s", NULL);
     pipeline_command_args (p, "grep", "t", NULL);
     status = pipeline_run (p);

--- a/examples_tests/test_libpipeline.py
+++ b/examples_tests/test_libpipeline.py
@@ -25,9 +25,8 @@ class LibPipelineTestCase(examples_tests.ExampleTestCase):
         self.build_snap(self.example_dir)
         self.install_snap(self.example_dir, 'pipelinetest', '1.0')
         expected = (
-            'running ls | grep c\n'
+            'running echo test | grep s | grep t\n'
             'custom libpipeline called\n'
-            'command-pipelinetest.wrapper\n'
-            'include\n')
+            'test\n')
         self.assert_command_in_snappy_testbed(
             '/snaps/bin/pipelinetest.pipelinetest', expected)


### PR DESCRIPTION
The libpipeline examples tests the pipe using ls. Now that the snap is
run in an empty working directory, the result of ls is empty.

LP: #1554637