### PR TITLE
travis: run the tests in the GCE trusty machine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,31 +13,13 @@ env:
   matrix:
   - TEST_SUITE=static
   - TEST_SUITE=unit
-  - TEST_SUITE=integration
-
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y python3-coverage python3-distutils-extra
 install:
-  - sudo apt-add-repository -y ppa:ubuntu-lxc/lxd-stable
-  - sudo apt-get update -qq
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" -y dist-upgrade || true
-  - sudo apt-get install -qq lxd lxcfs || true
-before_script:
-  - sudo lxd-images import ubuntu xenial --stream daily --alias ubuntu
-  - sudo lxc launch ubuntu xenial
-  # Wait for the container to get an IP address.
-  - while ! sudo lxc info xenial | grep -q eth0.*inet; do sleep 5s; done
-  # Allow the container user to do everything on the repository.
-  - sudo chmod 777 $(pwd)
-  # Mount the repository directory in the container.
-  - sudo lxc config device add xenial /dev/sda1 disk source=$(pwd) path=$(pwd)
-  # Install the snapcraft dependencies.
-  - sudo lxc exec xenial -- apt-get update
-  - sudo lxc exec xenial -- apt-get install -y devscripts equivs
-  - sudo lxc exec xenial -- mk-build-deps --install --tool "apt-get -y" --build-dep $(pwd)/debian/control
-  - sudo lxc exec xenial -- apt-get install -y lxd pyflakes python-flake8 python3.5 python3-apt python3-coverage python3-flake8 python3-mccabe python3-pep8 python3-pexpect python3-pip python3-testtools python3-lxml python3-progressbar python3-requests-toolbelt squashfs-tools
-  - sudo lxc exec xenial -- usermod ubuntu -a -G lxd
+  - pip install docopt fixtures flake8 jsonschema lxml mccabe petname pexpect python-apt pyxdg pyyaml py3-progressbar requests requests-oauthlib requests-toolbelt responses setuptools ssoclient testscenarios
 script:
-  - sudo -E lxc exec xenial -- su - ubuntu -c "cd $(pwd); TEST_USER_PASSWORD=$TEST_USER_PASSWORD ./runtests.sh $TEST_SUITE"
+  - ./runtests.sh $TEST_SUITE
 after_success:
-  - sudo apt-get install -qq python3-docopt python3-coverage || true
   - pip install coveralls
   - coveralls

--- a/examples_tests/__init__.py
+++ b/examples_tests/__init__.py
@@ -15,12 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import atexit
-import http.client
 import logging
 import os
 import re
 import tempfile
-import time
 import shutil
 import subprocess
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -44,7 +44,7 @@ parseargs(){
 
 run_static_tests(){
     SRC_PATHS="bin snapcraft snapcraft/tests examples_tests"
-    python3 /usr/bin/flake8 $SRC_PATHS
+    python3 -m flake8 $SRC_PATHS
 
     mccabe_list=
     for unit in $(find snapcraft -type f -name '*.py')
@@ -63,8 +63,8 @@ run_static_tests(){
 
 run_unit_tests(){
     if which python3-coverage >/dev/null 2>&1; then
-        python3-coverage erase
-        python3-coverage run --branch --source snapcraft -m unittest discover -s snapcraft -t .
+        python3 -m coverage erase
+        python3 -m coverage run --branch --source snapcraft -m unittest discover -s snapcraft -t .
         mv .coverage .coverage.unit
     else
         python3 -m unittest discover -s snapcraft -t .
@@ -73,7 +73,7 @@ run_unit_tests(){
 
 run_integration(){
     if which python3-coverage >/dev/null 2>&1; then
-        python3-coverage erase
+        python3 -m coverage erase
         export SNAPCRAFT=snapcraft-coverage
     fi
 
@@ -82,7 +82,7 @@ run_integration(){
 
 run_examples(){
     if which python3-coverage >/dev/null 2>&1; then
-        python3-coverage erase
+        python3 -m coverage erase
         export SNAPCRAFT=snapcraft-coverage
     fi
 
@@ -114,8 +114,8 @@ fi
 
 if [ ! -z "$RUN_UNIT" -o ! -z "$RUN_INTEGRATION" ]; then
     if which python3-coverage >/dev/null 2>&1; then
-        python3-coverage combine
-        python3-coverage report
+        python3 -m coverage combine
+        python3 -m coverage report
 
         echo
         echo "Run 'python3-coverage html' to get a nice report"


### PR DESCRIPTION
We applied a hack in travis to get a xenial LXC and run the tests in
there. Something changed and now the tests are taking an excessive
amount of time, and timing out. We no longer need this tests to run in
xenial because we are already running them in Jenkins, so we can get rid
of the hack.

LP: #1555386