### PR TITLE
Remove Unicode quotes from help text

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -99,13 +99,13 @@ be used in any part irrespective of the plugin, these are
       `parts/<part-name>/install`.
     - stage:
       (list of strings)
-      A list of files from a part’s installation to expose in `stage`.
+      A list of files from a part's installation to expose in `stage`.
       Rules applying to the list here are the same as those of filesets.
       Referencing of fileset keys is done with a $ prefixing the fileset
       key, which will expand with the value of such key.
     - snap:
       (list of strings)
-      A list of files from a part’s installation to expose in `snap`.
+      A list of files from a part's installation to expose in `snap`.
       Rules applying to the list here are the same as those of filesets.
       Referencing of fileset keys is done with a $ prefixing the fileset
       key, which will expand with the value of such key.

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -33,7 +33,7 @@ Options:
                          CPUs)
 
 The available commands are:
-  list-parts   List available parts which are like “source packages” for snaps.
+  list-parts   List available parts which are like "source packages" for snaps.
   list-plugins List the available plugins that handle different types of part.
   init         Initialize a snapcraft project.
   add-part     Add a part to your snapcraft.yaml, interactively presenting


### PR DESCRIPTION
Help text has Unicode quotes in a few places, which breaks help output as noted in https://bugs.launchpad.net/snapcraft/+bug/1555733. This change replaces them with ASCII quotes

