### PR TITLE
Also set CXXFLAGS

### DIFF
--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -330,6 +330,13 @@ def _build_env(root):
         '-I{0}/usr/include/{1}',
         '$CFLAGS'
     ]).format(root, arch_triplet) + '"')
+    env.append('CXXFLAGS="' + ' '.join([
+        '-I{0}/include',
+        '-I{0}/usr/include',
+        '-I{0}/include/{1}',
+        '-I{0}/usr/include/{1}',
+        '$CFLAGS'
+    ]).format(root, arch_triplet) + '"')
     env.append('CPPFLAGS="' + ' '.join([
         '-I{0}/include',
         '-I{0}/usr/include',


### PR DESCRIPTION
Set CXXFLAGS on top of CPPFLAGS and CFLAGS; CFLAGS are specific to C builds, while CXXFLAGS is for C++ builds – CPPFLAGS is for pre-processor. Typically CFLAGS and CXXFLAGS should have -L flags, and CPPFLAGS -I/-D flags, but it's ok to repeat these across the defines, they will just be ignored.