### PR TITLE
Improve default cmake configure flags

### DIFF
--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -71,7 +71,8 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
 
         env = self._build_environment()
 
-        self.run(['cmake', sourcedir, '-DCMAKE_INSTALL_PREFIX='] +
+        self.run(['cmake', sourcedir, '-DCMAKE_INSTALL_PREFIX=',
+                  '-DCMAKE_BUILD_TYPE=None', '-DCMAKE_VERBOSE_MAKEFILE=ON'] +
                  self.options.configflags, env=env)
 
         self.run(['make', '-j{}'.format(common.get_parallel_build_count())],


### PR DESCRIPTION
This extends the default cmake configure flags to produce verbose builds by default (more useful logging and easier for debugging) and to avoid the default build type which might select release or debug options. Debhelper uses these same options for all cmake builds.