### PR TITLE
Fix run()'s shell quoting

### DIFF
--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -51,7 +51,7 @@ def run(cmd, **kwargs):
     with tempfile.NamedTemporaryFile(mode='w+') as f:
         f.write(assemble_env())
         f.write('\n')
-        f.write('exec $*')
+        f.write('exec "$@"')
         f.flush()
         subprocess.check_call(['/bin/sh', f.name] + cmd, **kwargs)
 


### PR DESCRIPTION
"$@" is the proper way to expand original positional args; $* will perform an extra IFS split.

NB: I realize that I'm not following proper contribution rules and that I have other branches to update, but I didn't want to lose this one  :-)