### PR TITLE
Correct local source pulling

### DIFF
--- a/snapcraft/sources.py
+++ b/snapcraft/sources.py
@@ -251,10 +251,14 @@ class Tar(Base):
 class Local(Base):
 
     def pull(self):
-        if os.path.isdir(self.source_dir):
+        if os.path.islink(self.source_dir):
+            os.remove(self.source_dir)
+        elif (os.path.isdir(self.source_dir) and
+              not os.listdir(self.source_dir)):
             os.rmdir(self.source_dir)
         else:
-            os.remove(self.source_dir)
+            raise EnvironmentError('Cannot pull to target {!r}'.format(
+                self.source_dir))
 
         source_abspath = os.path.abspath(self.source)
         os.symlink(source_abspath, self.source_dir)

--- a/snapcraft/tests/test_sources.py
+++ b/snapcraft/tests/test_sources.py
@@ -299,9 +299,31 @@ class TestLocal(tests.TestCase):
         self.assertTrue(os.path.islink('source_dir'))
         self.assertEqual(os.path.realpath('source_dir'), self.path)
 
-    def test_pull_with_existing_source_file_creates_symlink(self):
+    def test_pull_with_existing_source_file_fails(self):
         open('source_dir', 'w').close()
         local = snapcraft.sources.Local('.', 'source_dir')
+
+        with self.assertRaises(EnvironmentError) as raised:
+            local.pull()
+
+        self.assertEqual("Cannot pull to target 'source_dir'",
+                         str(raised.exception))
+
+    def test_pull_with_source_dir_with_content_fails(self):
+        os.mkdir('source_dir')
+        open(os.path.join('source_dir', 'file'), 'w').close()
+        local = snapcraft.sources.Local('.', 'source_dir')
+
+        with self.assertRaises(EnvironmentError) as raised:
+            local.pull()
+
+        self.assertEqual("Cannot pull to target 'source_dir'",
+                         str(raised.exception))
+
+    def test_pulling_twice_with_existing_source_dir_creates_symlink(self):
+        os.mkdir('source_dir')
+        local = snapcraft.sources.Local('.', 'source_dir')
+        local.pull()
         local.pull()
 
         self.assertTrue(os.path.islink('source_dir'))


### PR DESCRIPTION
isdir evaluates to true as it follows symlinks by default and
later fails when doing an rmdir, so we invert the check and we
also specifically check for a link or fail in a controlled way
if not for healthier user output.

This also fixes the case where you could not pull twice with the
"is a symlink error".

LP: #1558446

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>