### PR TITLE
docs - Fix indentation of 'cam' example.

### DIFF
--- a/docs/snapcraft-advanced-features.md
+++ b/docs/snapcraft-advanced-features.md
@@ -230,11 +230,11 @@ cam:
       - fswebcam
     filesets:
       fswebcam:
-      - usr/bin/fswebcam
-      - lib
-      - usr/lib
-    go-server:
-      - bin/golang-*
+        - usr/bin/fswebcam
+        - lib
+        - usr/lib
+      go-server:
+        - bin/golang-*
     stage:
       - $fswebcam
       - $go-server


### PR DESCRIPTION
Line up the filesets.