### PR TITLE
Improve per-step state tracking.

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -62,3 +62,14 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
         os.chdir(tempdir_obj.name)
         with open('snapcraft.yaml', 'w', encoding=encoding) as fp:
             fp.write(content)
+
+    def verify_state(self, part_name, state_dir, expected_step):
+        self.assertTrue(os.path.isdir(state_dir),
+                        'Expected state directory for {}'.format(part_name))
+
+        # Expect every step up to and including the specified one to be run
+        index = common.COMMAND_ORDER.index(expected_step)
+        for step in common.COMMAND_ORDER[:index+1]:
+            self.assertTrue(os.path.exists(os.path.join(state_dir, step)),
+                            'Expected {!r} to be run for {}'.format(
+                                step, part_name))

--- a/snapcraft/tests/test_commands_build.py
+++ b/snapcraft/tests/test_commands_build.py
@@ -50,10 +50,10 @@ parts:
         parts = []
         for i in range(n):
             part_dir = os.path.join(common.get_partsdir(), 'build{}'.format(i))
-            state_file = os.path.join(part_dir, 'state')
+            state_dir = os.path.join(part_dir, 'state')
             parts.append({
                 'part_dir': part_dir,
-                'state_file': state_file,
+                'state_dir': state_dir,
             })
 
         return parts
@@ -81,15 +81,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the build0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the build0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build0 part')
-        self.assertEqual(state[0], 'build', "Expected the state file for "
-                         "build0 to be 'build'")
+        self.verify_state('build0', parts[0]['state_dir'], 'build')
 
     def test_build_one_part_only_from_3(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -102,18 +95,11 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[1]['part_dir']),
                         'Expected a part directory for the build1 part')
-        self.assertTrue(os.path.exists(parts[1]['state_file']),
-                        'Expected a state file for the build1 part')
 
-        with open(parts[1]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build1 part')
-        self.assertEqual(state[0], 'build', "Expected the state file for "
-                         " build1 to be 'build'")
+        self.verify_state('build1', parts[1]['state_dir'], 'build')
 
         for i in [0, 2]:
             self.assertFalse(os.path.exists(parts[i]['part_dir']),
                              'Pulled wrong part')
-            self.assertFalse(os.path.exists(parts[i]['state_file']),
+            self.assertFalse(os.path.exists(parts[i]['state_dir']),
                              'Expected for only to be a state file for build1')

--- a/snapcraft/tests/test_commands_pull.py
+++ b/snapcraft/tests/test_commands_pull.py
@@ -50,10 +50,10 @@ parts:
         parts = []
         for i in range(n):
             part_dir = os.path.join(common.get_partsdir(), 'pull{}'.format(i))
-            state_file = os.path.join(part_dir, 'state')
+            state_dir = os.path.join(part_dir, 'state')
             parts.append({
                 'part_dir': part_dir,
-                'state_file': state_file,
+                'state_dir': state_dir,
             })
 
         return parts
@@ -81,15 +81,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the pull0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the pull0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the pull0 part')
-        self.assertEqual(state[0], 'pull', "Expected the state file for pull0 "
-                         "to be 'pull'")
+        self.verify_state('pull0', parts[0]['state_dir'], 'pull')
 
     def test_pull_one_part_only_from_3(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -102,18 +95,11 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[1]['part_dir']),
                         'Expected a part directory for the pull1 part')
-        self.assertTrue(os.path.exists(parts[1]['state_file']),
-                        'Expected a state file for the pull1 part')
 
-        with open(parts[1]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the pull1 part')
-        self.assertEqual(state[0], 'pull', "Expected the state file for pull1 "
-                         "to be 'pull'")
+        self.verify_state('pull1', parts[1]['state_dir'], 'pull')
 
         for i in [0, 2]:
             self.assertFalse(os.path.exists(parts[i]['part_dir']),
                              'Pulled wrong part')
-            self.assertFalse(os.path.exists(parts[i]['state_file']),
+            self.assertFalse(os.path.exists(parts[i]['state_dir']),
                              'Expected for only to be a state file for pull1')

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -43,7 +43,7 @@ parts:
 
     def make_snapcraft_yaml(self, n=1):
         super().make_snapcraft_yaml(self.yaml_template)
-        self.state_file = os.path.join(common.get_partsdir(), 'part1', 'state')
+        self.state_dir = os.path.join(common.get_partsdir(), 'part1', 'state')
 
     @mock.patch('subprocess.check_call')
     def test_snap_defaults(self, mock_call):
@@ -64,15 +64,8 @@ parts:
 
         self.assertTrue(os.path.exists(common.get_stagedir()),
                         'Expected a stage directory')
-        self.assertTrue(self.state_file,
-                        'Expected a state file for the part1 part')
 
-        with open(self.state_file) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the part1 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "part1 to be 'strip'")
+        self.verify_state('part1', self.state_dir, 'strip')
 
         mock_call.assert_called_once_with([
             'mksquashfs', common.get_snapdir(), 'snap-test_1.0_amd64.snap',
@@ -84,9 +77,9 @@ parts:
         self.useFixture(fake_logger)
         self.make_snapcraft_yaml()
 
-        os.makedirs(os.path.dirname(self.state_file))
-        with open(self.state_file, 'w') as f:
-            f.write('strip')
+        # Pretend this part has already been stripped
+        os.makedirs(self.state_dir)
+        open(os.path.join(self.state_dir, 'strip'), 'w').close()
 
         snap.main()
 
@@ -146,15 +139,8 @@ architectures: [amd64, armhf]
 
         self.assertTrue(os.path.exists(common.get_stagedir()),
                         'Expected a stage directory')
-        self.assertTrue(self.state_file,
-                        'Expected a state file for the part1 part')
 
-        with open(self.state_file) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the part1 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "part1 to be 'strip'")
+        self.verify_state('part1', self.state_dir, 'strip')
 
         mock_call.assert_called_once_with([
             'mksquashfs', common.get_snapdir(), 'mysnap.snap',

--- a/snapcraft/tests/test_commands_stage.py
+++ b/snapcraft/tests/test_commands_stage.py
@@ -50,10 +50,10 @@ parts:
         parts = []
         for i in range(n):
             part_dir = os.path.join(common.get_partsdir(), 'stage{}'.format(i))
-            state_file = os.path.join(part_dir, 'state')
+            state_dir = os.path.join(part_dir, 'state')
             parts.append({
                 'part_dir': part_dir,
-                'state_file': state_file,
+                'state_dir': state_dir,
             })
 
         return parts
@@ -83,15 +83,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the build0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the build0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build0 part')
-        self.assertEqual(state[0], 'stage', "Expected the state file for "
-                         "build0 to be 'stage'")
+        self.verify_state('build0', parts[0]['state_dir'], 'stage')
 
     def test_stage_one_part_only_from_3(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -106,20 +99,13 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[1]['part_dir']),
                         'Expected a part directory for the stage1 part')
-        self.assertTrue(os.path.exists(parts[1]['state_file']),
-                        'Expected a state file for the stage1 part')
 
-        with open(parts[1]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the stage1 part')
-        self.assertEqual(state[0], 'stage', "Expected the state file for "
-                         " stage1 to be 'stage'")
+        self.verify_state('stage1', parts[1]['state_dir'], 'stage')
 
         for i in [0, 2]:
             self.assertFalse(os.path.exists(parts[i]['part_dir']),
                              'Pulled wrong part')
-            self.assertFalse(os.path.exists(parts[i]['state_file']),
+            self.assertFalse(os.path.exists(parts[i]['state_dir']),
                              'Expected for only to be a state file for build1')
 
     def test_stage_ran_twice_is_a_noop(self):
@@ -141,15 +127,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the build0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the build0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build0 part')
-        self.assertEqual(state[0], 'stage', "Expected the state file for "
-                         "build0 to be 'stage'")
+        self.verify_state('build0', parts[0]['state_dir'], 'stage')
 
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)

--- a/snapcraft/tests/test_commands_strip.py
+++ b/snapcraft/tests/test_commands_strip.py
@@ -50,10 +50,10 @@ parts:
         parts = []
         for i in range(n):
             part_dir = os.path.join(common.get_partsdir(), 'strip{}'.format(i))
-            state_file = os.path.join(part_dir, 'state')
+            state_dir = os.path.join(part_dir, 'state')
             parts.append({
                 'part_dir': part_dir,
-                'state_file': state_file,
+                'state_dir': state_dir,
             })
 
         return parts
@@ -89,15 +89,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the build0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the build0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build0 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "build0 to be 'strip'")
+        self.verify_state('build0', parts[0]['state_dir'], 'strip')
 
     def test_strip_one_part_only_from_3(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -118,20 +111,13 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[1]['part_dir']),
                         'Expected a part directory for the strip1 part')
-        self.assertTrue(os.path.exists(parts[1]['state_file']),
-                        'Expected a state file for the strip1 part')
 
-        with open(parts[1]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the strip1 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         " strip1 to be 'strip'")
+        self.verify_state('strip1', parts[1]['state_dir'], 'strip')
 
         for i in [0, 2]:
             self.assertFalse(os.path.exists(parts[i]['part_dir']),
                              'Pulled wrong part')
-            self.assertFalse(os.path.exists(parts[i]['state_file']),
+            self.assertFalse(os.path.exists(parts[i]['state_dir']),
                              'Expected for only to be a state file for build1')
 
     def test_strip_ran_twice_is_a_noop(self):
@@ -154,15 +140,8 @@ parts:
                         'Expected a parts directory')
         self.assertTrue(os.path.exists(parts[0]['part_dir']),
                         'Expected a part directory for the build0 part')
-        self.assertTrue(os.path.exists(parts[0]['state_file']),
-                        'Expected a state file for the build0 part')
 
-        with open(parts[0]['state_file']) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the build0 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "build0 to be 'strip'")
+        self.verify_state('build0', parts[0]['state_dir'], 'strip')
 
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)

--- a/snapcraft/tests/test_commands_upload.py
+++ b/snapcraft/tests/test_commands_upload.py
@@ -67,7 +67,7 @@ parts:
 
     def make_snapcraft_yaml(self, n=1):
         super().make_snapcraft_yaml(self.yaml_template)
-        self.state_file = os.path.join(common.get_partsdir(), 'part1', 'state')
+        self.statedir = os.path.join(common.get_partsdir(), 'part1', 'state')
 
     def test_upload(self):
         upload.main()
@@ -85,15 +85,7 @@ parts:
 
         self.assertTrue(os.path.exists(common.get_stagedir()),
                         'Expected a stage directory')
-        self.assertTrue(self.state_file,
-                        'Expected a state file for the part1 part')
-
-        with open(self.state_file) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the part1 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "part1 to be 'strip'")
+        self.verify_state('part1', self.statedir, 'strip')
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',
@@ -118,15 +110,7 @@ parts:
 
         self.assertTrue(os.path.exists(common.get_stagedir()),
                         'Expected a stage directory')
-        self.assertTrue(self.state_file,
-                        'Expected a state file for the part1 part')
-
-        with open(self.state_file) as sf:
-            state = sf.readlines()
-        self.assertEqual(len(state), 1, 'Expected only one line in the state '
-                         'file for the part1 part')
-        self.assertEqual(state[0], 'strip', "Expected the state file for "
-                         "part1 to be 'strip'")
+        self.verify_state('part1', self.statedir, 'strip')
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',
@@ -141,7 +125,7 @@ parts:
         # stages are not build if snap file already exists
         self.assertFalse(os.path.exists(common.get_stagedir()),
                          'Expected a stage directory')
-        self.assertFalse(os.path.exists(self.state_file))
+        self.assertFalse(os.path.exists(self.statedir))
 
         self.mock_upload.assert_called_once_with(
             'snap-test_1.0_amd64.snap',


### PR DESCRIPTION
This PR resolves LP: [#1558810](https://bugs.launchpad.net/snapcraft/+bug/1558810) by moving from a single state file to per-step state files. This is necessary for future changes, such as tracking dirty state and per-step cleaning rules.