### PR TITLE
Support per-step clean command.

### DIFF
--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -25,6 +25,8 @@ Usage:
 
 Options:
   -h --help             show this help message and exit.
+  -s STEP --step=STEP   only clean the specified step and those that depend
+                        upon it.
 """
 
 import os
@@ -39,6 +41,36 @@ from snapcraft import common
 logger = logging.getLogger(__name__)
 
 
+def _reverse_dependency_tree(config, part_name):
+    dependents = config.part_dependents(part_name)
+    for dependent in dependents.copy():
+        # No need to worry about infinite recursion due to circular
+        # dependencies since the YAML validation won't allow it.
+        dependents |= _reverse_dependency_tree(config, dependent)
+
+    return dependents
+
+
+def _clean_part_and_all_dependents(config, part, staged_state, stripped_state,
+                                   step):
+    cleaned_parts = set()
+
+    # Clean the part in question
+    part.clean(staged_state, stripped_state, step)
+    cleaned_parts.add(part.name)
+
+    # Now obtain the reverse dependency tree for this part. Make sure
+    # all dependents are also cleaned.
+    dependents = _reverse_dependency_tree(config, part.name)
+    cleaned_parts |= dependents
+    dependent_parts = {p for p in config.all_parts
+                       if p.name in dependents}
+    for dependent_part in dependent_parts:
+        dependent_part.clean(staged_state, stripped_state, step)
+
+    return cleaned_parts
+
+
 def main(argv=None):
     argv = argv if argv else []
     args = docopt(__doc__, argv=argv)
@@ -48,16 +80,25 @@ def main(argv=None):
     if args['PART']:
         config.validate_parts(args['PART'])
 
-    for part in config.all_parts:
-        if not args['PART'] or part.name in args['PART']:
-            part.clean()
+    staged_state = config.get_project_state('stage')
+    stripped_state = config.get_project_state('strip')
 
-    # parts dir does not contain only generated code.
+    cleaned_parts = set()
+    for part in config.all_parts:
+        if not args['PART']:
+            part.clean(staged_state, stripped_state, args['--step'])
+            cleaned_parts.add(part.name)
+        elif part.name in args['PART']:
+            cleaned_parts |= _clean_part_and_all_dependents(
+                config, part, staged_state, stripped_state, args['--step'])
+
+    # parts dir does not contain only generated code, so only blow it away if
+    # there's nothing left inside it.
     if (os.path.exists(common.get_partsdir()) and
             not os.listdir(common.get_partsdir())):
         os.rmdir(common.get_partsdir())
 
-    parts_match = set(config.part_names) == set(args['PART'])
+    parts_match = set(config.part_names) == cleaned_parts
     # Only clean stage if all the parts were cleaned up.
     clean_stage = not args['PART'] or parts_match
     if clean_stage and os.path.exists(common.get_stagedir()):

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -510,6 +510,44 @@ parts:
             'stage': ['/usr/lib/wget.so', '/usr/bin/wget', '/usr/lib/wget.a'],
         })
 
+    def test_part_prereqs(self):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+
+parts:
+  main:
+    plugin: nil
+
+  dependent:
+    plugin: nil
+    after: [main]
+""")
+        config = snapcraft.yaml.Config()
+
+        self.assertFalse(config.part_prereqs('main'))
+        self.assertEqual({'main'}, config.part_prereqs('dependent'))
+
+    def test_part_dependents(self):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+
+parts:
+  main:
+    plugin: nil
+
+  dependent:
+    plugin: nil
+    after: [main]
+""")
+        config = snapcraft.yaml.Config()
+
+        self.assertFalse(config.part_dependents('dependent'))
+        self.assertEqual({'dependent'}, config.part_dependents('main'))
+
 
 class TestYamlEnvironment(tests.TestCase):
 

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -227,6 +227,25 @@ class Config:
         """Returns a set with all of part_names' prerequisites."""
         return set(self.after_requests.get(part_name, []))
 
+    def part_dependents(self, part_name):
+        """Returns a set of all the parts that depend upon part_name."""
+
+        dependents = set()
+        for part, prerequisites in self.after_requests.items():
+            if part_name in prerequisites:
+                dependents.add(part)
+
+        return dependents
+
+    def get_project_state(self, step):
+        """Returns a dict of states for the given step of each part."""
+
+        state = {}
+        for part in self.all_parts:
+            state[part.name] = part.get_state(step)
+
+        return state
+
     def validate_parts(self, part_names):
         for part_name in part_names:
             if part_name not in self._part_names:


### PR DESCRIPTION
This PR makes progress on LP: [#1537786](https://bugs.launchpad.net/snapcraft/+bug/1537786) by adding a --step argument to the clean command, cleaning reverse dependencies, and implementing per-step clean rules. All per-step clean rules are placeholders to be implemented in subsequent PRs.