### PR TITLE
busybox example: update the expected results

### DIFF
--- a/examples_tests/__init__.py
+++ b/examples_tests/__init__.py
@@ -161,20 +161,21 @@ class ExampleTestCase(testtools.TestCase):
 
     def assert_command_in_snappy_testbed(self, command, expected_output):
         if not config.get('skip-install', False):
-            output = self._run_command_in_snappy_testbed(command)
+            output = self.run_command_in_snappy_testbed(command)
             self.assertEqual(output, expected_output)
 
-    def _run_command_in_snappy_testbed(self, command):
-        try:
-            return self.snappy_testbed.run_command(command)
-        except subprocess.CalledProcessError as e:
-            self.addDetail(
-                'ssh output', content.text_content(str(e.output)))
-            raise
+    def run_command_in_snappy_testbed(self, command):
+        if not config.get('skip-install', False):
+            try:
+                return self.snappy_testbed.run_command(command)
+            except subprocess.CalledProcessError as e:
+                self.addDetail(
+                    'ssh output', content.text_content(str(e.output)))
+                raise
 
     def assert_service_running(self, snap, service):
         if not config.get('skip-install', False):
-            output = self._run_command_in_snappy_testbed(
+            output = self.run_command_in_snappy_testbed(
                 ['sudo', 'snappy', 'service', 'status', snap])
             expected = (
                 'Snap\t+Service\t+State\n'

--- a/examples_tests/test_busybox.py
+++ b/examples_tests/test_busybox.py
@@ -24,7 +24,10 @@ class BusyBoxTestCase(examples_tests.ExampleTestCase):
     def test_busybox(self):
         self.build_snap(self.example_dir)
         self.install_snap(self.example_dir, 'busybox', '1.0')
-        # TODO once PWD issues are sorted make use of busybox.touch
-        # for a more complete test run.
         self.assert_command_in_snappy_testbed(
-            '/snaps/bin/busybox.ls', '')
+            ['/snaps/bin/busybox.touch', 'busybox.test'], '')
+        self.addCleanup(
+            self.run_command_in_snappy_testbed, ['rm', 'busybox.test'])
+        self.assert_command_in_snappy_testbed(
+            '/snaps/bin/busybox.ls',
+            'busybox.test\nbusybox_1.0_amd64.snap\nsnaps\n')


### PR DESCRIPTION
The next ubuntu-core release changes the directory where the command
is run. This lets us use busybox.touch and changes the expected
results of busybox.ls

LP: #1560255