### PR TITLE
libpipeline example test: update the binary name

### DIFF
--- a/examples_tests/test_libpipeline.py
+++ b/examples_tests/test_libpipeline.py
@@ -29,4 +29,4 @@ class LibPipelineTestCase(examples_tests.ExampleTestCase):
             'custom libpipeline called\n'
             'test\n')
         self.assert_command_in_snappy_testbed(
-            '/snaps/bin/pipelinetest.pipelinetest', expected)
+            '/snaps/bin/pipelinetest', expected)


### PR DESCRIPTION
The next ubuntu-core release changes the name of the binary of this
example. This update makes the test pass in rolling ubuntu-core/edge.

LP: #1560254