### PR TITLE
Snaps of type os should not squash with -all-root

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -124,6 +124,7 @@ properties:
     enum:
       - app
       - kernel
+      - os
   frameworks:
     type: array
     minItems: 1

--- a/snapcraft/commands/snap.py
+++ b/snapcraft/commands/snap.py
@@ -51,7 +51,8 @@ def _snap_data_from_dir(dir):
 
     return {'name': snap['name'],
             'version': snap['version'],
-            'arch': snap['architectures']}
+            'arch': snap['architectures'],
+            'type': snap.get('type', '')}
 
 
 def _format_snap_name(snap):
@@ -76,7 +77,10 @@ def main(argv=None):
     logger.info('Snapping {}'.format(snap_name))
     # These options need to match the review tools:
     # http://bazaar.launchpad.net/~click-reviewers/click-reviewers-tools/trunk/view/head:/clickreviews/common.py#L38
-    mksquashfs_args = ['-noappend', '-comp', 'xz', '-all-root', '-no-xattrs']
+    mksquashfs_args = ['-noappend', '-comp', 'xz', '-no-xattrs']
+    if snap['type'] != 'os':
+        mksquashfs_args.append('-all-root')
+
     subprocess.check_call(
         ['mksquashfs', snap_dir, snap_name] + mksquashfs_args)
     logger.info('Snapped {}'.format(snap_name))

--- a/snapcraft/lifecycle.py
+++ b/snapcraft/lifecycle.py
@@ -54,7 +54,8 @@ def execute(step, part_names=None):
 
     return {'name': config.data['name'],
             'version': config.data['version'],
-            'arch': config.data['architectures']}
+            'arch': config.data['architectures'],
+            'type': config.data.get('type', '')}
 
 
 class _Executor:

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -19,6 +19,7 @@ import logging
 import fixtures
 
 from snapcraft import (
+    common,
     lifecycle,
     tests,
 )
@@ -71,7 +72,15 @@ parts:
 """)
         open('icon.png', 'w').close()
 
-        lifecycle.execute('pull')
+        snap_info = lifecycle.execute('pull')
+
+        expected_snap_info = {
+            'name': 'after',
+            'version': 0,
+            'arch': [common.get_arch()],
+            'type': ''
+        }
+        self.assertEqual(snap_info, expected_snap_info)
 
         self.assertEqual(
             'Pulling part1 \n'
@@ -81,3 +90,33 @@ parts:
             'Staging part1 \n'
             'Pulling part2 \n',
             fake_logger.output)
+
+    def test_os_type_returned_by_lifecycle(self):
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml("""name: after
+version: 0
+summary: test stage
+description: check and see if we return type 'os'
+type: os
+
+parts:
+  part1:
+    plugin: nil
+  part2:
+    plugin: nil
+    after:
+      - part1
+""")
+        open('icon.png', 'w').close()
+
+        snap_info = lifecycle.execute('pull')
+
+        expected_snap_info = {
+            'name': 'after',
+            'version': 0,
+            'arch': [common.get_arch()],
+            'type': 'os'
+        }
+        self.assertEqual(snap_info, expected_snap_info)

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -698,6 +698,7 @@ class TestValidation(tests.TestCase):
         valid_types = [
             'app',
             'kernel',
+            'os',
         ]
 
         for t in valid_types:
@@ -711,7 +712,6 @@ class TestValidation(tests.TestCase):
             'framework',
             'platform',
             'oem',
-            'os',
         ]
 
         for t in invalid_types:
@@ -725,7 +725,8 @@ class TestValidation(tests.TestCase):
 
                 expected_message = (
                     "The 'type' property does not match the required "
-                    "schema: '{}' is not one of ['app', 'kernel']").format(t)
+                    "schema: '{}' is not one of "
+                    "['app', 'kernel', 'os']").format(t)
                 self.assertEqual(raised.exception.message, expected_message,
                                  msg=data)
 


### PR DESCRIPTION
When creating os snaps we want to preserve user permissions.

LP: #1557513

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>