### PR TITLE
Support architecture all packages when snapping

### DIFF
--- a/snapcraft/commands/snap.py
+++ b/snapcraft/commands/snap.py
@@ -51,12 +51,18 @@ def _snap_data_from_dir(dir):
 
     return {'name': snap['name'],
             'version': snap['version'],
-            'arch': snap['architectures'],
+            'arch': snap.get('architectures', []),
             'type': snap.get('type', '')}
 
 
 def _format_snap_name(snap):
-    snap['arch'] = snap['arch'][0] if len(snap['arch']) == 1 else 'multi'
+    if not snap['arch']:
+        snap['arch'] = 'all'
+    elif len(snap['arch']) == 1:
+        snap['arch'] = snap['arch'][0]
+    else:
+        snap['arch'] = 'multi'
+
     return '{name}_{version}_{arch}.snap'.format(**snap)
 
 

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -149,6 +149,29 @@ architectures: [amd64, armhf]
             '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'])
 
     @mock.patch('subprocess.check_call')
+    def test_snap_from_dir_with_no_arch(self, mock_call):
+        fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(fake_logger)
+
+        meta_dir = os.path.join('mysnap', 'meta')
+        os.makedirs(meta_dir)
+        with open(os.path.join(meta_dir, 'snap.yaml'), 'w') as f:
+            f.write("""name: my_snap
+version: 99
+""")
+
+        snap.main(['mysnap'])
+
+        self.assertEqual(
+            'Snapping my_snap_99_all.snap\n'
+            'Snapped my_snap_99_all.snap\n',
+            fake_logger.output)
+
+        mock_call.assert_called_once_with([
+            'mksquashfs', os.path.abspath('mysnap'), 'my_snap_99_all.snap',
+            '-noappend', '-comp', 'xz', '-no-xattrs', '-all-root'])
+
+    @mock.patch('subprocess.check_call')
     def test_snap_from_dir_type_os_does_not_use_all_root(self, mock_call):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)


### PR DESCRIPTION
When snapping a directory we want to support architecture all
by omission of mentioning the architecture.

LP: #1560481

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>