### PR TITLE
Support cleaning stage step.

### DIFF
--- a/integration_tests/test_clean_stage_step.py
+++ b/integration_tests/test_clean_stage_step.py
@@ -1,0 +1,113 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    DirExists,
+    FileExists,
+    Not
+)
+
+import integration_tests
+
+
+class CleanStageStepStagedTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_dir = 'independent-parts'
+        self.run_snapcraft('stage', self.project_dir)
+        self.stagedir = os.path.join(self.project_dir, 'stage')
+        self.bindir = os.path.join(self.stagedir, 'bin')
+
+    def verify_files_exist(self):
+        self.assertThat(os.path.join(self.bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(self.bindir, 'file2'), FileExists())
+
+    def test_clean_stage_step(self):
+        self.verify_files_exist()
+
+        self.run_snapcraft(['clean', '--step=stage'], self.project_dir)
+        self.assertThat(self.stagedir, Not(DirExists()))
+        self.assertThat(os.path.join(self.project_dir, 'parts'), DirExists())
+
+        # Now try to stage again
+        self.run_snapcraft('stage', self.project_dir)
+        self.verify_files_exist()
+
+    def test_clean_stage_step_single_part(self):
+        self.verify_files_exist()
+
+        self.run_snapcraft(['clean', 'part1', '--step=stage'],
+                           self.project_dir)
+        self.assertThat(os.path.join(self.bindir, 'file1'), Not(FileExists()))
+        self.assertThat(os.path.join(self.bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.project_dir, 'parts'), DirExists())
+
+        # Now try to stage again
+        self.run_snapcraft('stage', self.project_dir)
+        self.verify_files_exist()
+
+
+class CleanStageStepStrippedTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_dir = 'independent-parts'
+        self.run_snapcraft('strip', self.project_dir)
+
+        self.snapdir = os.path.join(self.project_dir, 'snap')
+        self.snap_bindir = os.path.join(self.snapdir, 'bin')
+        self.stagedir = os.path.join(self.project_dir, 'stage')
+        self.stage_bindir = os.path.join(self.stagedir, 'bin')
+
+    def verify_files_exist(self):
+        self.assertThat(os.path.join(self.snap_bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(self.snap_bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.stage_bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(self.stage_bindir, 'file2'), FileExists())
+
+    def test_clean_stage_step(self):
+        self.verify_files_exist()
+
+        self.run_snapcraft(['clean', '--step=stage'], self.project_dir)
+        self.assertThat(self.stagedir, Not(DirExists()))
+        self.assertThat(self.snapdir, Not(DirExists()))
+        self.assertThat(os.path.join(self.project_dir, 'parts'), DirExists())
+
+        # Now try to strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.verify_files_exist()
+
+    def test_clean_stage_step_single_part(self):
+        self.verify_files_exist()
+
+        self.run_snapcraft(['clean', 'part1', '--step=stage'],
+                           self.project_dir)
+        self.assertThat(os.path.join(self.stage_bindir, 'file1'),
+                        Not(FileExists()))
+        self.assertThat(os.path.join(self.stage_bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.snap_bindir, 'file1'),
+                        Not(FileExists()))
+        self.assertThat(os.path.join(self.snap_bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.project_dir, 'parts'), DirExists())
+
+        # Now try to strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.verify_files_exist()

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -136,9 +136,9 @@ parts:
         clean.main(['--step=foo'])
 
         expected_staged_state = {
-            'clean0': {},
-            'clean1': {},
-            'clean2': {},
+            'clean0': pluginhandler.StageState({'clean0'}, set()),
+            'clean1': pluginhandler.StageState({'clean1'}, set()),
+            'clean2': pluginhandler.StageState({'clean2'}, set()),
         }
 
         expected_stripped_state = {


### PR DESCRIPTION
This PR makes progress on LP: [#1537786](https://bugs.launchpad.net/snapcraft/+bug/1537786) by adding the ability to clean only a part's staged files. This takes into account the possibility for parts to share files, and such files are not removed.