### PR TITLE
Fixed assets go into a setup dir

### DIFF
--- a/snapcraft/meta.py
+++ b/snapcraft/meta.py
@@ -100,13 +100,39 @@ def _setup_assets(meta_dir, config_data):
         _setup_config_hook(hooks_dir, config_data['config'])
 
     if 'license' in config_data:
+        logger.warning("DEPRECATED: 'license' defined in snapcraft.yaml")
         license_path = os.path.join(meta_dir, 'license.txt')
-        shutil.copyfile(config_data['license'], license_path)
+        os.link(config_data['license'], license_path)
 
     if 'icon' in config_data:
+        logger.warning("DEPRECATED: 'icon' defined in snapcraft.yaml")
         icon_ext = config_data['icon'].split(os.path.extsep)[1]
-        icon_path = os.path.join(meta_dir, 'icon.{}'.format(icon_ext))
-        shutil.copyfile(config_data['icon'], icon_path)
+        icon_dir = os.path.join(meta_dir, 'gui')
+        icon_path = os.path.join(icon_dir, 'icon.{}'.format(icon_ext))
+        os.mkdir(icon_dir)
+        os.link(config_data['icon'], icon_path)
+
+    _setup_from_setup(meta_dir)
+
+
+def _setup_from_setup(meta_dir):
+    setup_dir = 'setup'
+    if not os.path.exists(setup_dir):
+        return
+
+    gui_src = os.path.join(setup_dir, 'gui')
+    gui_dst = os.path.join(meta_dir, 'gui')
+    if os.path.exists(gui_dst) and os.path.exists(gui_src):
+        shutil.rmtree(gui_dst)
+    if os.path.exists(gui_src):
+        shutil.copytree(gui_src, gui_dst)
+
+    license_src = os.path.join(setup_dir, 'license.txt')
+    license_dst = os.path.join(meta_dir, 'license.txt')
+    if os.path.exists(license_dst) and os.path.exists(license_src):
+        os.unlink(license_dst)
+    if os.path.exists(license_src):
+        os.link(license_src, license_dst)
 
 
 def _setup_config_hook(hooks_dir, config):

--- a/snapcraft/tests/test_commands_strip.py
+++ b/snapcraft/tests/test_commands_strip.py
@@ -33,7 +33,6 @@ class StripCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test strip
 description: if the strip is succesful the state file will be updated
-icon: icon.png
 
 parts:
 {parts}"""
@@ -45,7 +44,6 @@ parts:
     def make_snapcraft_yaml(self, n=1):
         parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])
         super().make_snapcraft_yaml(self.yaml_template.format(parts=parts))
-        open('icon.png', 'w').close()
 
         parts = []
         for i in range(n):

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -61,7 +61,7 @@ class CreateTest(tests.TestCase):
 
         self.assertEqual(y, expected)
 
-    def test_create_meta_with_license(self):
+    def test_create_meta_with_declared_license(self):
         open(os.path.join(os.curdir, 'LICENSE'), 'w').close()
         self.config_data['license'] = 'LICENSE'
 
@@ -79,15 +79,109 @@ class CreateTest(tests.TestCase):
         self.assertFalse('license' in y,
                          'license found in snap.yaml {}'.format(y))
 
-    def test_create_meta_with_icon(self):
+    def test_create_meta_with_declared_license_and_setup(self):
+        open(os.path.join(os.curdir, 'LICENSE'), 'w').close()
+        self.config_data['license'] = 'LICENSE'
+
+        os.mkdir('setup')
+        license_text = 'this is the license'
+        with open(os.path.join('setup', 'license.txt'), 'w') as f:
+            f.write(license_text)
+
+        meta.create(self.config_data)
+
+        expected_license = os.path.join(self.meta_dir, 'license.txt')
+        self.assertTrue(os.path.exists(expected_license),
+                        'license.txt was not setup correctly')
+        with open(expected_license) as f:
+            self.assertEqual(f.read(), license_text)
+
+        self.assertTrue(
+            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
+        with open(self.snap_yaml) as f:
+            y = yaml.load(f)
+        self.assertFalse('license' in y,
+                         'license found in snap.yaml {}'.format(y))
+
+    def test_create_meta_with_license_in_setup(self):
+        os.mkdir('setup')
+        license_text = 'this is the license'
+        with open(os.path.join('setup', 'license.txt'), 'w') as f:
+            f.write(license_text)
+
+        meta.create(self.config_data)
+
+        expected_license = os.path.join(self.meta_dir, 'license.txt')
+        self.assertTrue(os.path.exists(expected_license),
+                        'license.txt was not setup correctly')
+        with open(expected_license) as f:
+            self.assertEqual(f.read(), license_text)
+
+        self.assertTrue(
+            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
+        with open(self.snap_yaml) as f:
+            y = yaml.load(f)
+        self.assertFalse('license' in y,
+                         'license found in snap.yaml {}'.format(y))
+
+    def test_create_meta_with_declared_icon(self):
         open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
         self.config_data['icon'] = 'my-icon.png'
 
         meta.create(self.config_data)
 
         self.assertTrue(
-            os.path.exists(os.path.join(self.meta_dir, 'icon.png')),
+            os.path.exists(os.path.join(self.meta_dir, 'gui', 'icon.png')),
             'icon.png was not setup correctly')
+
+        self.assertTrue(
+            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
+
+        with open(self.snap_yaml) as f:
+            y = yaml.load(f)
+        self.assertFalse('icon' in y,
+                         'icon found in snap.yaml {}'.format(y))
+
+    def test_create_meta_with_declared_icon_and_setup(self):
+        gui_path = os.path.join('setup', 'gui')
+        os.makedirs(gui_path)
+        icon_content = b'this is the icon'
+        with open(os.path.join(gui_path, 'icon.png'), 'wb') as f:
+            f.write(icon_content)
+
+        open(os.path.join(os.curdir, 'my-icon.png'), 'w').close()
+        self.config_data['icon'] = 'my-icon.png'
+
+        meta.create(self.config_data)
+
+        expected_icon = os.path.join(self.meta_dir, 'gui', 'icon.png')
+        self.assertTrue(os.path.exists(expected_icon),
+                        'icon.png was not setup correctly')
+        with open(expected_icon, 'rb') as f:
+            self.assertEqual(f.read(), icon_content)
+
+        self.assertTrue(
+            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
+
+        with open(self.snap_yaml) as f:
+            y = yaml.load(f)
+        self.assertFalse('icon' in y,
+                         'icon found in snap.yaml {}'.format(y))
+
+    def test_create_meta_with_icon_in_setup(self):
+        gui_path = os.path.join('setup', 'gui')
+        os.makedirs(gui_path)
+        icon_content = b'this is the icon'
+        with open(os.path.join(gui_path, 'icon.png'), 'wb') as f:
+            f.write(icon_content)
+
+        meta.create(self.config_data)
+
+        expected_icon = os.path.join(self.meta_dir, 'gui', 'icon.png')
+        self.assertTrue(os.path.exists(expected_icon),
+                        'icon.png was not setup correctly')
+        with open(expected_icon, 'rb') as f:
+            self.assertEqual(f.read(), icon_content)
 
         self.assertTrue(
             os.path.exists(self.snap_yaml), 'snap.yaml was not created')


### PR DESCRIPTION
Instead of declaring fixed assets we put them into a `setup` dir.
Implementation for gui (including icon) and license provided.

LP: 1560969

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>