### PR TITLE
Support cleaning pull step.

### DIFF
--- a/integration_tests/test_clean_pull_step.py
+++ b/integration_tests/test_clean_pull_step.py
@@ -1,0 +1,150 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from testtools.matchers import (
+    DirExists,
+    FileExists,
+    Not
+)
+
+import integration_tests
+
+
+class CleanPullStepPulledTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_dir = 'independent-parts'
+        self.run_snapcraft('pull', self.project_dir)
+        self.partsdir = os.path.join(self.project_dir, 'parts')
+        self.part1_sourcedir = os.path.join(self.partsdir, 'part1', 'src')
+        self.part2_sourcedir = os.path.join(self.partsdir, 'part2', 'src')
+
+    def assert_files_exist(self):
+        self.assertThat(os.path.join(self.part1_sourcedir, 'file1'),
+                        FileExists())
+        self.assertThat(os.path.join(self.part2_sourcedir, 'file2'),
+                        FileExists())
+
+    def test_clean_pull_step(self):
+        self.assert_files_exist()
+
+        self.run_snapcraft(['clean', '--step=pull'], self.project_dir)
+        self.assertThat(self.part1_sourcedir, Not(DirExists()))
+        self.assertThat(self.part2_sourcedir, Not(DirExists()))
+
+        # Now try to pull again
+        self.run_snapcraft('pull', self.project_dir)
+        self.assert_files_exist()
+
+    def test_clean_pull_step_single_part(self):
+        self.assert_files_exist()
+
+        self.run_snapcraft(['clean', 'part1', '--step=pull'],
+                           self.project_dir)
+        self.assertThat(self.part1_sourcedir, Not(DirExists()))
+        self.assertThat(os.path.join(self.part2_sourcedir, 'file2'),
+                        FileExists())
+
+        # Now try to pull again
+        self.run_snapcraft('pull', self.project_dir)
+        self.assert_files_exist()
+
+
+class CleanPullStepStrippedTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_dir = 'independent-parts'
+        self.run_snapcraft('strip', self.project_dir)
+
+        self.snapdir = os.path.join(self.project_dir, 'snap')
+        self.snap_bindir = os.path.join(self.snapdir, 'bin')
+        self.stagedir = os.path.join(self.project_dir, 'stage')
+        self.stage_bindir = os.path.join(self.stagedir, 'bin')
+        self.partsdir = os.path.join(self.project_dir, 'parts')
+        self.parts = {}
+        for part in ['part1', 'part2']:
+            partdir = os.path.join(self.partsdir, part)
+            self.parts[part] = {
+                'partdir': partdir,
+                'sourcedir': os.path.join(partdir, 'src'),
+                'builddir': os.path.join(partdir, 'build'),
+                'installdir': os.path.join(partdir, 'install'),
+                'bindir': os.path.join(partdir, 'install', 'bin'),
+            }
+
+    def assert_files_exist(self):
+        for d in ['builddir', 'bindir', 'sourcedir']:
+            self.assertThat(os.path.join(self.parts['part1'][d], 'file1'),
+                            FileExists())
+            self.assertThat(os.path.join(self.parts['part2'][d], 'file2'),
+                            FileExists())
+
+        self.assertThat(os.path.join(self.snap_bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(self.snap_bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.stage_bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(self.stage_bindir, 'file2'), FileExists())
+
+    def test_clean_pull_step(self):
+        self.assert_files_exist()
+
+        self.run_snapcraft(['clean', '--step=pull'], self.project_dir)
+        self.assertThat(self.stagedir, Not(DirExists()))
+        self.assertThat(self.snapdir, Not(DirExists()))
+
+        for part_name, part in self.parts.items():
+            self.assertThat(part['builddir'], Not(DirExists()))
+            self.assertThat(part['installdir'], Not(DirExists()))
+            self.assertThat(part['sourcedir'], Not(DirExists()))
+
+        # Now try to strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.assert_files_exist()
+
+    def test_clean_pull_step_single_part(self):
+        self.assert_files_exist()
+
+        self.run_snapcraft(['clean', 'part1', '--step=pull'],
+                           self.project_dir)
+        self.assertThat(os.path.join(self.stage_bindir, 'file1'),
+                        Not(FileExists()))
+        self.assertThat(os.path.join(self.stage_bindir, 'file2'), FileExists())
+        self.assertThat(os.path.join(self.snap_bindir, 'file1'),
+                        Not(FileExists()))
+        self.assertThat(os.path.join(self.snap_bindir, 'file2'), FileExists())
+
+        self.assertThat(self.parts['part1']['builddir'], Not(DirExists()))
+        self.assertThat(self.parts['part1']['installdir'], Not(DirExists()))
+        self.assertThat(self.parts['part1']['sourcedir'], Not(DirExists()))
+
+        self.assertThat(
+            os.path.join(self.parts['part2']['builddir'], 'file2'),
+            FileExists())
+        self.assertThat(
+            os.path.join(self.parts['part2']['bindir'], 'file2'),
+            FileExists())
+        self.assertThat(
+            os.path.join(self.parts['part2']['sourcedir'], 'file2'),
+            FileExists())
+
+        # Now try to strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.assert_files_exist()

--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -207,6 +207,19 @@ class BasePlugin:
         if getattr(self.options, 'source', None):
             sources.get(self.sourcedir, self.build_basedir, self.options)
 
+    def clean_pull(self):
+        """Clean the pulled source for this part.
+
+        The base implementation simply removes the sourcedir. Override this
+        method if your pull process was more involved and needs more cleaning.
+        """
+
+        if os.path.exists(self.sourcedir):
+            if os.path.islink(self.sourcedir):
+                os.remove(self.sourcedir)
+            else:
+                shutil.rmtree(self.sourcedir)
+
     def build(self):
         """Build the source code retrieved from the pull phase.
 

--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -83,6 +83,14 @@ def _cleanup_common_directories(config):
             if index > max_index:
                 max_index = index
 
+    # If no parts have been pulled, remove the parts directory. In most cases
+    # this directory should have already been cleaned, but this handles the
+    # case of a failed pull.
+    should_remove_partsdir = max_index < common.COMMAND_ORDER.index('pull')
+    if should_remove_partsdir and os.path.exists(common.get_partsdir()):
+        logger.info('Cleaning up parts directory')
+        shutil.rmtree(common.get_partsdir())
+
     # If no parts have been staged, remove staging area.
     should_remove_stagedir = max_index < common.COMMAND_ORDER.index('stage')
     if should_remove_stagedir and os.path.exists(common.get_stagedir()):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -98,6 +98,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
         # Get a unique set of packages
         self.catkin_packages = set(options.catkin_packages)
+        self._rosdep_path = os.path.join(self.partdir, 'rosdep')
 
         # The path created via the `source` key (or a combination of `source`
         # and `source-subdir` keys) needs to point to a valid Catkin workspace
@@ -180,8 +181,7 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
         # Use rosdep for dependency detection and resolution
         rosdep = _Rosdep(self.options.rosdistro, self._ros_package_path,
-                         os.path.join(self.partdir, 'rosdep'),
-                         self.PLUGIN_STAGE_SOURCES)
+                         self._rosdep_path, self.PLUGIN_STAGE_SOURCES)
         rosdep.setup()
 
         # Parse the Catkin packages to pull out their system dependencies
@@ -216,6 +216,13 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
             logger.info('Installing package dependencies...')
             ubuntu.unpack(self.installdir)
+
+    def clean_pull(self):
+        super().clean_pull()
+
+        # Remove the rosdep path, if any
+        if os.path.exists(self._rosdep_path):
+            shutil.rmtree(self._rosdep_path)
 
     @property
     def gcc_version(self):

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -90,6 +90,13 @@ class GoPlugin(snapcraft.BasePlugin):
             self._local_pull()
         self._remote_pull()
 
+    def clean_pull(self):
+        super().clean_pull()
+
+        # Remove the gopath (if present)
+        if os.path.exists(self._gopath):
+            shutil.rmtree(self._gopath)
+
     def _local_pull(self):
         go_package = os.path.basename(os.path.abspath(self.options.source))
         local_path = os.path.join(self._gopath_src, go_package)

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -33,6 +33,7 @@ Additionally, this plugin uses the following plugin-specific keywords:
 import logging
 import os
 import platform
+import shutil
 
 import snapcraft
 from snapcraft import sources
@@ -72,13 +73,20 @@ class NodePlugin(snapcraft.BasePlugin):
 
     def __init__(self, name, options):
         super().__init__(name, options)
-        self._nodejs_tar = sources.Tar(_get_nodejs_release(),
-                                       os.path.join(self.partdir, 'npm'))
+        self._npm_dir = os.path.join(self.partdir, 'npm')
+        self._nodejs_tar = sources.Tar(_get_nodejs_release(), self._npm_dir)
 
     def pull(self):
         super().pull()
         os.makedirs(os.path.join(self.partdir, 'npm'))
         self._nodejs_tar.pull()
+
+    def clean_pull(self):
+        super().clean_pull()
+
+        # Remove the npm directory (if any)
+        if os.path.exists(self._npm_dir):
+            shutil.rmtree(self._npm_dir)
 
     def build(self):
         super().build()

--- a/snapcraft/tests/test_base_plugin.py
+++ b/snapcraft/tests/test_base_plugin.py
@@ -228,3 +228,35 @@ class CleanBuildTestCase(tests.TestCase):
 
         # Make sure the install directory is gone
         self.assertFalse(os.path.exists(plugin.installdir))
+
+
+class CleanPullTestCase(tests.TestCase):
+
+    def test_clean_pull_directory(self):
+        options = tests.MockOptions(source='src')
+        plugin = snapcraft.BasePlugin('test_plugin', options)
+
+        os.makedirs(plugin.sourcedir)
+        source_file = os.path.join(plugin.sourcedir, 'source')
+        open(source_file, 'w').close()
+
+        plugin.clean_pull()
+
+        # The source directory should now be gone
+        self.assertFalse(os.path.exists(plugin.sourcedir))
+
+    def test_clean_pull_symlink(self):
+        options = tests.MockOptions(source='src')
+        plugin = snapcraft.BasePlugin('test_plugin', options)
+
+        real_source_directory = os.path.join(os.getcwd(), 'src')
+        os.mkdir(real_source_directory)
+        os.makedirs(plugin.partdir)
+        os.symlink(real_source_directory, plugin.sourcedir)
+
+        plugin.clean_pull()
+
+        # The source symlink should now be gone, but the real source should
+        # still be there.
+        self.assertFalse(os.path.exists(plugin.sourcedir))
+        self.assertTrue(os.path.isdir(real_source_directory))

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -59,6 +59,7 @@ parts:
                 open(os.path.join(
                     handler.code.installdir, part_name), 'w').close()
 
+                handler.mark_done('pull')
                 handler.mark_done('build')
 
                 handler.stage()

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -316,6 +316,22 @@ class CatkinPluginTestCase(tests.TestCase):
         self.assertEqual(str(raised.exception),
                          'Unable to determine system dependency for roscore')
 
+    def test_clean_pull(self):
+        plugin = catkin.CatkinPlugin('test-part', self.properties)
+        os.makedirs(os.path.join(plugin.sourcedir, 'src'))
+
+        self.dependencies_mock.return_value = {'foo', 'bar', 'baz'}
+
+        plugin.pull()
+
+        self.assertTrue(os.path.exists(plugin._ros_package_path))
+        os.makedirs(plugin._rosdep_path)
+
+        plugin.clean_pull()
+
+        self.assertFalse(os.path.exists(plugin._ros_package_path))
+        self.assertFalse(os.path.exists(plugin._rosdep_path))
+
     def test_valid_catkin_workspace_src(self):
         # sourcedir is expected to be the root of the Catkin workspace. Since
         # it contains a 'src' directory, this is a valid Catkin workspace.

--- a/snapcraft/tests/test_plugin_go.py
+++ b/snapcraft/tests/test_plugin_go.py
@@ -217,3 +217,21 @@ class GoPluginTestCase(tests.TestCase):
         self.assertTrue(os.path.exists(plugin._gopath_src))
         self.assertFalse(os.path.exists(plugin._gopath_bin))
         self.assertFalse(os.path.exists(plugin._gopath_pkg))
+
+    def test_clean_pull(self):
+        class Options:
+            source = 'dir'
+            go_packages = []
+
+        plugin = go.GoPlugin('test-part', Options())
+
+        os.makedirs(plugin.options.source)
+        os.makedirs(plugin.sourcedir)
+
+        plugin.pull()
+
+        self.assertTrue(os.path.exists(plugin._gopath))
+
+        plugin.clean_pull()
+
+        self.assertFalse(os.path.exists(plugin._gopath))

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -136,3 +136,20 @@ class NodePluginTestCase(tests.TestCase):
         schema_mock.return_value = {'properties': {}}
 
         self.assertTrue('required' not in nodejs.NodePlugin.schema())
+
+    def test_clean_pull_step(self):
+        class Options:
+            source = '.'
+            node_packages = []
+
+        plugin = nodejs.NodePlugin('test-part', Options())
+
+        os.makedirs(plugin.sourcedir)
+
+        plugin.pull()
+
+        self.assertTrue(os.path.exists(plugin._npm_dir))
+
+        plugin.clean_pull()
+
+        self.assertFalse(os.path.exists(plugin._npm_dir))


### PR DESCRIPTION
This PR finishes up LP: [#1537786](https://bugs.launchpad.net/snapcraft/+bug/1537786) by adding the ability to clean only a part's pulled files. This involves adding a new `clean_pull()` method to the plugin API as there are a few plugins that have more involved pull steps than the base implementation's.

This commit also reimplements clean_pull() for the Go, NodeJS, and Catkin plugins.

Depends upon #398.