### PR TITLE
Added valid STEPs info to clean command

### DIFF
--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -26,8 +26,8 @@ Usage:
 Options:
   -h --help             show this help message and exit.
   -s STEP --step=STEP   only clean the specified step and those that depend
-                        upon it. STEP can be one of: pull, build, stage, strip,
-                        snap. See 'snapcraft help plugins' to learn more.
+                        upon it. STEP can be one of: pull, build, stage, strip.
+                        See 'snapcraft help plugins' to learn more.
 """
 
 import os

--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -26,7 +26,8 @@ Usage:
 Options:
   -h --help             show this help message and exit.
   -s STEP --step=STEP   only clean the specified step and those that depend
-                        upon it.
+                        upon it. STEP can be one of: pull, build, stage, strip,
+                        snap. See 'snapcraft help plugins' to learn more.
 """
 
 import os


### PR DESCRIPTION
Added information of the valid STEP values to pass to `snapcraft clean -s`. The extra info will be shown on the output of `snapcraft clean --help`.