### PR TITLE
Clean: Leave local plugins alone.

### DIFF
--- a/integration_tests/test_local_plugin.py
+++ b/integration_tests/test_local_plugin.py
@@ -29,3 +29,14 @@ class LocalPluginTestCase(integration_tests.TestCase):
 
         self.assertThat(
             os.path.join(project_dir, 'stage', 'build-stamp'), FileExists())
+
+    def test_clean_local_plugin(self):
+        project_dir = 'local-plugin'
+        self.run_snapcraft('stage', project_dir)
+
+        # Now clean, and verify that the local plugin is still there.
+        self.run_snapcraft('clean', project_dir)
+
+        self.assertThat(
+            os.path.join(project_dir, 'parts', 'plugins', 'x_local_plugin.py'),
+            FileExists(), 'Expected local plugin to remain when cleaned')

--- a/snapcraft/commands/clean.py
+++ b/snapcraft/commands/clean.py
@@ -85,9 +85,11 @@ def _cleanup_common_directories(config):
 
     # If no parts have been pulled, remove the parts directory. In most cases
     # this directory should have already been cleaned, but this handles the
-    # case of a failed pull.
-    should_remove_partsdir = max_index < common.COMMAND_ORDER.index('pull')
-    if should_remove_partsdir and os.path.exists(common.get_partsdir()):
+    # case of a failed pull. Note however that the presence of local plugins
+    # should prevent this removal.
+    if (max_index < common.COMMAND_ORDER.index('pull') and
+            os.path.exists(common.get_partsdir()) and not
+            os.path.exists(common.get_local_plugindir())):
         logger.info('Cleaning up parts directory')
         shutil.rmtree(common.get_partsdir())
 

--- a/snapcraft/common.py
+++ b/snapcraft/common.py
@@ -165,6 +165,10 @@ def get_snapdir():
     return os.path.join(os.getcwd(), 'snap')
 
 
+def get_local_plugindir():
+    return os.path.abspath(os.path.join(get_partsdir(), 'plugins'))
+
+
 def set_plugindir(plugindir):
     global _plugindir
     _plugindir = plugindir

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -37,10 +37,6 @@ _SNAPCRAFT_STAGE = '$SNAPCRAFT_STAGE'
 logger = logging.getLogger(__name__)
 
 
-def _local_plugindir():
-    return os.path.abspath(os.path.join('parts', 'plugins'))
-
-
 class PluginError(Exception):
     pass
 
@@ -567,7 +563,7 @@ def _get_plugin(module):
 
 
 def _load_local(module_name):
-    sys.path = [_local_plugindir()] + sys.path
+    sys.path = [common.get_local_plugindir()] + sys.path
     module = importlib.import_module(module_name)
     sys.path.pop(0)
 

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -76,6 +76,20 @@ parts:
         self.assertFalse(os.path.exists(common.get_stagedir()))
         self.assertFalse(os.path.exists(common.get_snapdir()))
 
+    def test_local_plugin_not_removed(self):
+        self.make_snapcraft_yaml(n=3)
+
+        local_plugin = os.path.join(common.get_local_plugindir(), 'foo.py')
+        os.makedirs(os.path.dirname(local_plugin))
+        open(local_plugin, 'w').close()
+
+        clean.main()
+
+        self.assertFalse(os.path.exists(common.get_stagedir()))
+        self.assertFalse(os.path.exists(common.get_snapdir()))
+        self.assertTrue(os.path.exists(common.get_partsdir()))
+        self.assertTrue(os.path.isfile(local_plugin))
+
     def test_clean_all_when_all_parts_specified(self):
         self.make_snapcraft_yaml(n=3)
 


### PR DESCRIPTION
Currently Snapcraft will remove the parts directory if no parts are using it, but it doesn't take into account the fact that local plugins are kept in there, and will remove them. This PR fixes LP: [#1561546](https://bugs.launchpad.net/snapcraft/+bug/1561546) by checking for local plugins before removing the parts directory. It also adds tests so that this regression can't happen again.