### PR TITLE
Fix test isolation issues.

### DIFF
--- a/snapcraft/tests/test_commands_help.py
+++ b/snapcraft/tests/test_commands_help.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
+import pydoc
 from unittest import mock
 
 import fixtures
@@ -24,6 +25,14 @@ from snapcraft.commands import help
 
 
 class HelpCommandTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        # pydoc pager guess can fail, for tests we want a plain pager
+        # anyway
+        p = mock.patch('pydoc.pager', new=pydoc.plainpager)
+        p.start()
+        self.addCleanup(p.stop)
 
     def test_topic_and_plugin_not_found_exits_with_tip(self):
         fake_logger = fixtures.FakeLogger()

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import platform
 import re
 from unittest.mock import patch
 
@@ -112,8 +111,15 @@ class ArchTestCase(testtools.TestCase):
 
     def setUp(self):
         super().setUp()
-        common.host_machine = platform.machine()
-        common.target_machine = common.host_machine
+        # tests will override host_machine, protect it first
+        patcher = patch('snapcraft.common.host_machine',
+                        new=common.host_machine)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = patch('snapcraft.common.target_machine',
+                        new=common.host_machine)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_get_arch_with_no_errors(self):
         common.get_arch()


### PR DESCRIPTION
LP: 1563965

Two root causes:
- missing patch() leaving dirty 'badarch' in snapcraft.common.target_machine,
- pydoc.pager automatic detection failing for wrong reasons.