### PR TITLE
VCS tools are test dependencies…

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -5,6 +5,9 @@ Depends: @builddeps@
 Tests: integrationtests examplestests
 Restrictions: allow-stderr, isolation-container, rw-build-tree
 Depends: @,
+         bzr,
+         git,
+         mercurial,
          lxd,
          python3-pep8,
          pyflakes,

--- a/integration_tests/test_bzr_source.py
+++ b/integration_tests/test_bzr_source.py
@@ -16,14 +16,19 @@
 
 import os
 import subprocess
+import shutil
 
 import integration_tests
 
 
 class BzrSourceTestCase(integration_tests.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        if shutil.which('bzr') is None:
+            self.skipTest('bzr is not installed')
+
     def _init_and_config_bzr(self):
-        subprocess.check_call(['sudo', 'apt-get', 'install', '-y', 'bzr'])
         subprocess.check_call(
             ['bzr', 'init', '.'],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/integration_tests/test_git_source.py
+++ b/integration_tests/test_git_source.py
@@ -16,14 +16,19 @@
 
 import os
 import subprocess
+import shutil
 
 import integration_tests
 
 
 class GitSourceTestCase(integration_tests.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        if shutil.which('git') is None:
+            self.skipTest('git is not installed')
+
     def _init_and_config_git(self):
-        subprocess.check_call(['sudo', 'apt-get', 'install', '-y', 'git'])
         subprocess.check_call(
             ['git', 'init', '.'], stdout=subprocess.DEVNULL)
         subprocess.check_call(

--- a/integration_tests/test_hg_source.py
+++ b/integration_tests/test_hg_source.py
@@ -16,6 +16,7 @@
 
 import os
 import subprocess
+import shutil
 
 from testtools.matchers import FileExists
 
@@ -26,8 +27,8 @@ class HgSourceTestCase(integration_tests.TestCase):
 
     def setUp(self):
         super().setUp()
-        subprocess.check_call(
-            ['sudo', 'apt-get', 'install', '-y', 'mercurial'])
+        if shutil.which('hg') is None:
+            self.skipTest('mercurial is not installed')
 
     def _get_hg_revno(self, path):
         return subprocess.check_output(


### PR DESCRIPTION
...they should be installed to run the tests or the tests should be skipped.

This allows tests to be run concurrently (apt-get can't be run concurrently
;) and brings the time to run both unit and integration tests from 5'47 to 1'43 with:

  PYTHONPATH=`pwd` ols-run-tests -m integration_tests -m snapcraft -c 8

which is nice ;)

No tests were hurt during the production of this patch ;)