### PR TITLE
Login with macaroons

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -76,8 +76,10 @@ class TestCase(testtools.TestCase):
             output = exception.output
         return output
 
-    def login(self, email='u1test+snapcraft@canonical.com',
+    def login(self, email=None,
               password=None, expect_success=True):
+        email = email or os.getenv('TEST_USER_EMAIL',
+                                   'u1test+snapcraft@canonical.com')
         password = password or os.getenv('TEST_USER_PASSWORD', None)
         if not password:
             self.skipTest('No password provided for the test user.')

--- a/integration_tests/test_login_logout.py
+++ b/integration_tests/test_login_logout.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import fixtures
+
 import integration_tests
 from snapcraft.tests import fixture_setup
 
@@ -23,13 +25,28 @@ class LoginLogoutTestCase(integration_tests.TestCase):
     def setUp(self):
         super().setUp()
         self.useFixture(fixture_setup.StagingStore())
+        self.useFixture(
+            fixtures.EnvironmentVariable('SNAPCRAFT_WITH_MACAROONS', None))
 
     def test_successful_login(self):
         self.addCleanup(self.logout)
         self.login(expect_success=True)
 
     def test_failed_login(self):
-        self.login(
-            'u1test+snapcraft@canonical.com',
-            'wrongpassword',
-            expect_success=False)
+        self.login(password='wrongpassword', expect_success=False)
+
+
+class LoginLogoutWithMacaroonsTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.useFixture(fixture_setup.StagingStore())
+        self.useFixture(
+            fixtures.EnvironmentVariable('SNAPCRAFT_WITH_MACAROONS', '1'))
+
+    def test_successful_login(self):
+        self.addCleanup(self.logout)
+        self.login(expect_success=True)
+
+    def test_failed_login(self):
+        self.login(password='wrongpassword', expect_success=False)

--- a/snapcraft/storeapi/__init__.py
+++ b/snapcraft/storeapi/__init__.py
@@ -17,5 +17,6 @@
 from .channels import get_channels, update_channels  # noqa
 from .info import get_info  # noqa
 from ._login import login  # noqa
+from ._macaroon_login import login as login_with_macaroons  # noqa
 from ._download import download  # noqa
 from ._upload import upload  # noqa

--- a/snapcraft/storeapi/_macaroon_login.py
+++ b/snapcraft/storeapi/_macaroon_login.py
@@ -45,28 +45,26 @@ def login(email, password, token_name='unused', otp=''):
         'UBUNTU_SSO_API_ROOT_URL', UBUNTU_SSO_API_ROOT_URL)
     client = V2ApiClient(endpoint=api_endpoint)
 
-    macaroon, error = get_root_macaroon()
+    macaroon, error = get_package_upload_macaroon()
     if macaroon is None:
         result['errors'] = error
     else:
-        result['body'] = dict(root_macaroon=macaroon)
         result['success'] = True
     if result['success']:
-        data = {'email': email, 'password': password,
-                'macaroon': result['body']['root_macaroon']}
+        data = {'email': email, 'password': password, 'macaroon': macaroon}
         if otp:
             data['otp'] = otp
-        macaroon, error = get_discharge_macaroon(client, data)
-        if macaroon is None:
+        discharge, error = get_discharge_macaroon(client, data)
+        if discharge is None:
             result['errors'] = error
             result['success'] = False
         else:
-            result['body']['discharge_macaroon'] = macaroon
+            result['body'] = dict(package_upload=(macaroon, discharge))
     return result
 
 
-def get_root_macaroon():
-    response = store_api_call('../../api/2.0/acl/package_access/',
+def get_package_upload_macaroon():
+    response = store_api_call('../../api/2.0/acl/package_upload/',
                               method='POST', data={})
     if response['success']:
         return response['data']['macaroon'], None

--- a/snapcraft/storeapi/_macaroon_login.py
+++ b/snapcraft/storeapi/_macaroon_login.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, unicode_literals
+import os
+
+from ssoclient.v2 import (
+    ApiException,
+    UnexpectedApiError,
+    V2ApiClient,
+)
+
+from .common import (
+    store_api_call,
+)
+from .constants import (
+    UBUNTU_SSO_API_ROOT_URL,
+)
+
+
+def login(email, password, token_name='unused', otp=''):
+    """Log in via the Ubuntu One SSO API.
+
+    If successful, returns the root and discharge macaroons.
+    """
+    result = {
+        'success': False,
+        'body': None,
+    }
+
+    api_endpoint = os.environ.get(
+        'UBUNTU_SSO_API_ROOT_URL', UBUNTU_SSO_API_ROOT_URL)
+    client = V2ApiClient(endpoint=api_endpoint)
+
+    macaroon, error = get_root_macaroon()
+    if macaroon is None:
+        result['errors'] = error
+    else:
+        result['body'] = dict(root_macaroon=macaroon)
+        result['success'] = True
+    if result['success']:
+        data = {'email': email, 'password': password,
+                'macaroon': result['body']['root_macaroon']}
+        if otp:
+            data['otp'] = otp
+        macaroon, error = get_discharge_macaroon(client, data)
+        if macaroon is None:
+            result['errors'] = error
+            result['success'] = False
+        else:
+            result['body']['discharge_macaroon'] = macaroon
+    return result
+
+
+def get_root_macaroon():
+    response = store_api_call('../../api/2.0/acl/package_access/',
+                              method='POST', data={})
+    if response['success']:
+        return response['data']['macaroon'], None
+    else:
+        return None, response['errors']
+
+
+def get_discharge_macaroon(client, data):
+    try:
+        response = client.session.post(
+            '/tokens/discharge', data=data,
+            headers={'Content-Type': 'application/json',
+                     'Accept': 'application/json'})
+        return response.content['discharge_macaroon'], None
+    except ApiException as err:
+        return None, err.body
+    except UnexpectedApiError as err:
+        return None, err.json_body

--- a/snapcraft/storeapi/common.py
+++ b/snapcraft/storeapi/common.py
@@ -54,7 +54,9 @@ def store_api_call(path, session=None, method='GET', data=None):
     if method == 'GET':
         response = client.get(url)
     elif method == 'POST':
-        response = client.post(url, data=data and json.dumps(data) or None,
+        if data is not None:
+            data = json.dumps(data)
+        response = client.post(url, data=data,
                                headers={'Content-Type': 'application/json'})
     else:
         raise ValueError('Method {} not supported'.format(method))

--- a/snapcraft/tests/test_commands_login.py
+++ b/snapcraft/tests/test_commands_login.py
@@ -158,7 +158,7 @@ class LoginWithMacaroonsCommandTestCase(tests.TestCase):
             self.fake_logger.output)
         self.assertFalse(self.mock_save.called)
 
-    def test_failed_disacharge_macaroon_does_not_save_config(self):
+    def test_failed_discharge_macaroon_does_not_save_config(self):
         response = ('root', None)
         self.mock_root_macaroon.return_value = response
         response = (None, 'Failed')

--- a/snapcraft/tests/test_commands_login.py
+++ b/snapcraft/tests/test_commands_login.py
@@ -125,7 +125,7 @@ class LoginWithMacaroonsCommandTestCase(tests.TestCase):
         self.addCleanup(patcher.stop)
 
         patcher = mock.patch(
-            'snapcraft.storeapi._macaroon_login.get_root_macaroon')
+            'snapcraft.storeapi._macaroon_login.get_package_upload_macaroon')
         self.mock_root_macaroon = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -135,7 +135,7 @@ class LoginWithMacaroonsCommandTestCase(tests.TestCase):
         self.addCleanup(patcher.stop)
 
     def test_successful_login_saves_config(self):
-        self.mock_root_macaroon.return_value = ('root', None)
+        self.mock_root_macaroon.return_value = ('macaroon', None)
         self.mock_discharge_macaroon.return_value = ('discharge', None)
 
         main(['login'])
@@ -145,7 +145,7 @@ class LoginWithMacaroonsCommandTestCase(tests.TestCase):
             'Login successful.\n',
             self.fake_logger.output)
         self.mock_save.assert_called_once_with(
-            dict(root_macaroon='root', discharge_macaroon='discharge'))
+            dict(package_upload=('macaroon', 'discharge')))
 
     def test_failed_root_macaroon_does_not_save_config(self):
         self.mock_root_macaroon.return_value = (None, 'Failed')

--- a/snapcraft/tests/test_commands_logout.py
+++ b/snapcraft/tests/test_commands_logout.py
@@ -25,7 +25,7 @@ from snapcraft import tests
 
 class LogoutCommandTestCase(tests.TestCase):
 
-    @mock.patch('snapcraft._store.clear_config')
+    @mock.patch('snapcraft.config.clear_config')
     def test_successful_login_saves_config(self, mock_clear):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)

--- a/snapcraft/tests/test_commands_upload.py
+++ b/snapcraft/tests/test_commands_upload.py
@@ -64,7 +64,7 @@ class UploadCommandTestCase(tests.TestCase):
         mock_upload = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = mock.patch('snapcraft._store.load_config')
+        patcher = mock.patch('snapcraft.config.load_config')
         mock_load_config = patcher.start()
         self.addCleanup(patcher.stop)
         mock_load_config.return_value = 'test config'

--- a/snapcraft/tests/test_storeapi_common.py
+++ b/snapcraft/tests/test_storeapi_common.py
@@ -153,6 +153,24 @@ class ApiCallTestCase(TestCase):
         self.assertEqual(responses.calls[0].request.body,
                          json.dumps({'request': 'value'}))
 
+    @responses.activate
+    def test_post_with_empty_data(self):
+        response_data = {'response': 'value'}
+        responses.add(responses.POST, 'http://example.com/path',
+                      body=json.dumps(response_data))
+
+        result = store_api_call(
+            '/path', method='POST', data={})
+        self.assertEqual(result, {
+            'success': True,
+            'data': response_data,
+            'errors': [],
+        })
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.headers['Content-Type'],
+                         'application/json')
+        self.assertEqual(responses.calls[0].request.body, '{}')
+
 
 class RetryDecoratorTestCase(TestCase):
 


### PR DESCRIPTION
This is the first step in the migration to use macaroons when talking to the store.

I've guarded the corresponding code behind the SNAPCRAFT_WITH_MACAROONS environment variable.

The config file is used for both kind of login and as far I've tested manually (for now), both can be used so the existing workflow is still usable.

Feedback welcome while I proceed with register, revision, upload and publish.
