### PR TITLE
Clean command: Don't automatically clean reverse dependencies.

### DIFF
--- a/integration_tests/snaps/dependencies/p4/Makefile
+++ b/integration_tests/snaps/dependencies/p4/Makefile
@@ -1,0 +1,8 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+	gcc -o p4 $(CFLAGS) $(LDFLAGS) p4.c -lp1 -lp2
+
+install:
+	mkdir -p $(DESTDIR)/bin
+	cp -a p4 $(DESTDIR)/bin

--- a/integration_tests/snaps/dependencies/p4/p4.c
+++ b/integration_tests/snaps/dependencies/p4/p4.c
@@ -1,0 +1,7 @@
+#include "p1.h"
+#include "p2.h"
+int main() {
+    p1();
+    p2();
+    return 0;
+}

--- a/integration_tests/snaps/dependencies/snapcraft.yaml
+++ b/integration_tests/snaps/dependencies/snapcraft.yaml
@@ -18,3 +18,7 @@ parts:
     plugin: make
     source: p3
     after: [p2]
+  p4:
+    plugin: make
+    source: p4
+    after: [p2]

--- a/integration_tests/test_clean_dependents.py
+++ b/integration_tests/test_clean_dependents.py
@@ -1,0 +1,169 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+
+from testtools.matchers import (
+    DirExists,
+    Not
+)
+
+import integration_tests
+
+
+class CleanDependentsTestCase(integration_tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.project_dir = 'dependencies'
+        self.run_snapcraft('strip', self.project_dir)
+
+        # Need to use the state directory here instead of partdir due to
+        # bug #1567054.
+        self.part_dirs = {
+            'p1': os.path.join(self.project_dir, 'parts', 'p1', 'state'),
+            'p2': os.path.join(self.project_dir, 'parts', 'p2', 'state'),
+            'p3': os.path.join(self.project_dir, 'parts', 'p3', 'state'),
+            'p4': os.path.join(self.project_dir, 'parts', 'p4', 'state'),
+        }
+
+        self.partsdir = os.path.join(self.project_dir, 'parts')
+        self.stagedir = os.path.join(self.project_dir, 'stage')
+        self.snapdir = os.path.join(self.project_dir, 'snap')
+
+    def assert_clean(self, parts, common=False):
+        for part in parts:
+            self.expectThat(
+                self.part_dirs[part], Not(DirExists()),
+                'Expected part directory for {!r} to be cleaned'.format(part))
+
+        if common:
+            self.expectThat(self.partsdir, Not(DirExists()),
+                            'Expected parts/ directory to be cleaned')
+            self.expectThat(self.stagedir, Not(DirExists()),
+                            'Expected stage/ directory to be cleaned')
+            self.expectThat(self.snapdir, Not(DirExists()),
+                            'Expected snap/ directory to be cleaned')
+
+    def assert_not_clean(self, parts, common=False):
+        for part in parts:
+            self.expectThat(
+                self.part_dirs[part], DirExists(),
+                'Expected part directory for {!r} to be uncleaned'.format(
+                    part))
+
+        if common:
+            self.expectThat(self.partsdir, DirExists(),
+                            'Expected parts/ directory to be uncleaned')
+            self.expectThat(self.stagedir, DirExists(),
+                            'Expected stage/ directory to be uncleaned')
+            self.expectThat(self.snapdir, DirExists(),
+                            'Expected snap/ directory to be uncleaned')
+
+    def test_clean_nested_dependent(self):
+        # Test that p3 (which has dependencies but no dependents) cleans with
+        # no extra parameters.
+        self.run_snapcraft(['clean', 'p3'], self.project_dir)
+        self.assert_clean(['p3'])
+        self.assert_not_clean(['p1', 'p2', 'p4'], True)
+
+        # Now run strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_dependent(self):
+        # Test that p2 (which has both dependencies and dependents) cleans with
+        # its dependents (p3 and p4) also specified.
+        self.run_snapcraft(['clean', 'p2', 'p3', 'p4'], self.project_dir)
+        self.assert_clean(['p2', 'p3', 'p4'])
+        self.assert_not_clean(['p1'], True)
+
+        # Now run strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_main(self):
+        # Test that p1 (which has no dependencies but dependents) cleans with
+        # its dependents (p2 and, as an extension, p3 and p4) also specified.
+        self.run_snapcraft(['clean', 'p1', 'p2', 'p3', 'p4'], self.project_dir)
+        self.assert_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+        # Now run strip again
+        self.run_snapcraft('strip', self.project_dir)
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_dependent_without_nested_dependents_raises(self):
+        # Test that p2 (which has both dependencies and dependents) fails to
+        # clean if its dependents (p3 and p4) are not also specified
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft, ['clean', 'p2'],
+            self.project_dir)
+        self.assertEqual(
+            "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. Please "
+            "add each to the clean command if that's what you intended.",
+            exception.output.replace('\n', ' ').strip())
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_dependent_without_nested_dependent_raises(self):
+        # Test that p2 (which has both dependencies and dependents) fails to
+        # clean if one of its dependents (p4) is not also specified
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['clean', 'p2', 'p3'], self.project_dir)
+        self.assertEqual(
+            "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. Please "
+            "add each to the clean command if that's what you intended.",
+            exception.output.replace('\n', ' ').strip())
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_main_without_any_dependent_raises(self):
+        # Test that p1 (which has no dependencies but dependents) fails to
+        # clean if none of its dependents are also specified.
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft, ['clean', 'p1'],
+            self.project_dir)
+        self.assertEqual(
+            "Requested clean of 'p1' but 'p2' depends upon it. Please add "
+            "each to the clean command if that's what you intended.",
+            exception.output.replace('\n', ' ').strip())
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_main_without_dependent_raises(self):
+        # Test that p1 (which has no dependencies but dependents) fails to
+        # clean if its dependent (p2) is not also specified
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['clean', 'p1', 'p3', 'p4'], self.project_dir)
+        self.assertEqual(
+            "Requested clean of 'p1' but 'p2' depends upon it. Please add "
+            "each to the clean command if that's what you intended.",
+            exception.output.replace('\n', ' ').strip())
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)
+
+    def test_clean_main_without_nested_dependent_raises(self):
+        # Test that p1 (which has no dependencies but dependents) fails to
+        # clean if its nested dependent (p3, by way of p2) is not also
+        # specified
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft,
+            ['clean', 'p1', 'p2'], self.project_dir)
+        self.assertEqual(
+            "Requested clean of 'p2' but 'p3' and 'p4' depend upon it. Please "
+            "add each to the clean command if that's what you intended.",
+            exception.output.replace('\n', ' ').strip())
+        self.assert_not_clean(['p1', 'p2', 'p3', 'p4'], True)

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -225,7 +225,9 @@ class PluginHandler:
 
         return None
 
-    def is_dirty(self, step):
+    def is_clean(self, step):
+        """Return true if the given step hasn't run (or has been cleaned)."""
+
         last_step = self.last_step()
         if last_step:
             return (common.COMMAND_ORDER.index(step) >
@@ -234,7 +236,7 @@ class PluginHandler:
         return True
 
     def should_step_run(self, step, force=False):
-        return force or self.is_dirty(step)
+        return force or self.is_clean(step)
 
     def mark_done(self, step, state=None):
         if not state:

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -141,3 +141,32 @@ description: test
             'type': 'os'
         }
         self.assertEqual(snap_info, expected_snap_info)
+
+
+class HumanizeListTestCases(tests.TestCase):
+
+    def test_no_items(self):
+        items = []
+        output = snapcraft.lifecycle._humanize_list(items)
+        self.assertEqual(output, '')
+
+    def test_one_item(self):
+        items = ['foo']
+        output = snapcraft.lifecycle._humanize_list(items)
+        self.assertEqual(output, "'foo'")
+
+    def test_two_items(self):
+        items = ['foo', 'bar']
+        output = snapcraft.lifecycle._humanize_list(items)
+        self.assertEqual(output, "'bar' and 'foo'",
+                         "Expected 'bar' before 'foo' due to sorting")
+
+    def test_three_items(self):
+        items = ['foo', 'bar', 'baz']
+        output = snapcraft.lifecycle._humanize_list(items)
+        self.assertEqual(output, "'bar', 'baz', and 'foo'")
+
+    def test_four_items(self):
+        items = ['foo', 'bar', 'baz', 'qux']
+        output = snapcraft.lifecycle._humanize_list(items)
+        self.assertEqual(output, "'bar', 'baz', 'foo', and 'qux'")

--- a/snapcraft/yaml.py
+++ b/snapcraft/yaml.py
@@ -240,6 +240,13 @@ class Config:
 
         return dependents
 
+    def get_part(self, part_name):
+        for part in self.all_parts:
+            if part.name == part_name:
+                return part
+
+        return None
+
     def get_project_state(self, step):
         """Returns a dict of states for the given step of each part."""
 


### PR DESCRIPTION
This PR resolves LP: [#1568004](https://bugs.launchpad.net/snapcraft/+bug/1568004) by making cleaning more consistent with the way parts are built (i.e. requiring that all interdependent parts be explicitly specified).