### PR TITLE
Automatically re-strip if dirty.

### DIFF
--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -16,30 +16,24 @@
 
 import yaml
 
-from snapcraft.internal.states._state import State
 
-
-def _strip_state_constructor(loader, node):
-    parameters = loader.construct_mapping(node)
-    return StripState(**parameters)
-
-yaml.add_constructor(u'!StripState', _strip_state_constructor)
-
-
-class StripState(State):
-    yaml_tag = u'!StripState'
-
+class State(yaml.YAMLObject):
     @classmethod
     def properties_of_interest(cls, options):
-        return {'snap': getattr(options, 'snap', ['*']) or ['*']}
+        return {}
 
-    def __init__(self, files, directories, dependency_paths=None,
-                 options=None):
-        super().__init__(options)
+    def __init__(self, options):
+        self.properties = self.properties_of_interest(options)
 
-        self.files = files
-        self.directories = directories
-        self.dependency_paths = set()
+    def __repr__(self):
+        items = sorted(self.__dict__.items())
+        strings = (': '.join((key, repr(value))) for key, value in items)
+        representation = ', '.join(strings)
 
-        if dependency_paths:
-            self.dependency_paths = dependency_paths
+        return '{}({})'.format(self.__class__.__name__, representation)
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.__dict__ == other.__dict__
+
+        return False

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -20,7 +20,12 @@ import yaml
 class State(yaml.YAMLObject):
     @classmethod
     def properties_of_interest(cls, options):
-        return {}
+        """Extract the properties concerning this step from the options.
+
+        Note that these options come from the YAML for a given part.
+        """
+
+        raise NotImplementedError
 
     def __init__(self, options):
         self.properties = self.properties_of_interest(options)

--- a/snapcraft/internal/states/_strip_state.py
+++ b/snapcraft/internal/states/_strip_state.py
@@ -31,6 +31,12 @@ class StripState(State):
 
     @classmethod
     def properties_of_interest(cls, options):
+        """Extract the properties concerning this step from the options.
+
+        The only property of interest to the strip step is the `snap` keyword
+        used to filter out files with a white or blacklist.
+        """
+
         return {'snap': getattr(options, 'snap', ['*']) or ['*']}
 
     def __init__(self, files, directories, dependency_paths=None,

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -185,8 +185,13 @@ class PluginHandler:
     def is_dirty(self, step):
         """Return true if the given step needs to run again."""
 
+        # Retrieve the stored state for this step (assuming it has already run)
         state = self.get_state(step)
         with contextlib.suppress(AttributeError):
+            # state.properties contains the old YAML that this step cares
+            # about, and we're comparing it to those same keys in the current
+            # YAML (taken from self.code.options). If they've changed, then
+            # this step is dirty and needs to run again.
             return state.properties != state.properties_of_interest(
                 self.code.options)
 
@@ -288,9 +293,6 @@ class PluginHandler:
         self.notify_part_progress('Cleaning build for', hint)
         self.code.clean_build()
         self.mark_cleaned('build')
-
-    def fileset_for(self, step):
-        return getattr(self.code.options, step, ['*']) or ['*']
 
     def migratable_fileset_for(self, step):
         plugin_fileset = self.code.snap_fileset()

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -208,7 +208,6 @@ class PluginTestCase(tests.TestCase):
                              'Expected staging to allow overwriting of '
                              'already-staged files')
 
-
     @patch('importlib.import_module')
     @patch('snapcraft.pluginhandler._load_local')
     @patch('snapcraft.pluginhandler._get_plugin')

--- a/snapcraft/tests/test_states_strip.py
+++ b/snapcraft/tests/test_states_strip.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import snapcraft.internal
+from snapcraft import tests
+
+
+class StripStateTestCase(tests.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.files = {'foo'}
+        self.directories = {'bar'}
+        self.dependency_paths = {'baz'}
+
+        class Options:
+            def __init__(self):
+                self.snap = ['qux']
+
+        self.options = Options()
+
+        self.state = snapcraft.internal.states.StripState(
+            self.files, self.directories, self.dependency_paths, self.options)
+
+    def test_representation(self):
+        expected = (
+            'StripState(dependency_paths: {}, directories: {}, files: {}, '
+            'properties: {})').format(self.dependency_paths, self.directories,
+                                      self.files, self.options.__dict__)
+        self.assertEqual(expected, repr(self.state))
+
+    def test_comparison(self):
+        other = snapcraft.internal.states.StripState(
+            self.files, self.directories, self.dependency_paths, self.options)
+
+        self.assertTrue(self.state == other, 'Expected states to be identical')
+
+    def test_comparison_not_equal(self):
+        others = [
+            snapcraft.internal.states.StripState(
+                set(), self.directories, self.dependency_paths,
+                self.options),
+            snapcraft.internal.states.StripState(
+                self.files, set(), self.dependency_paths,
+                self.options),
+            snapcraft.internal.states.StripState(
+                self.files, self.directories, set(),
+                self.options),
+            snapcraft.internal.states.StripState(
+                self.files, self.directories, self.dependency_paths,
+                None)
+        ]
+
+        for index, other in enumerate(others):
+            with self.subTest('other #{}'.format(index+1)):
+                self.assertFalse(self.state == other,
+                                 'Expected states to be different')


### PR DESCRIPTION
Currently Snapcraft doesn't notice YAML changes if a given step has already run-- it simply says that it already ran and halts execution. This PR makes progress on LP: [#1477904](https://bugs.launchpad.net/snapcraft/+bug/1477904) by changing that for the strip step, where now if one changes the `snap` keyword in the YAML, strip will notice that it's out of date and automatically clean itself and re-run.