### PR TITLE
Automatically re-stage if dirty.

### DIFF
--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -16,6 +16,8 @@
 
 import yaml
 
+from snapcraft.internal.states._state import State
+
 
 def _stage_state_constructor(loader, node):
     parameters = loader.construct_mapping(node)
@@ -24,19 +26,21 @@ def _stage_state_constructor(loader, node):
 yaml.add_constructor(u'!StageState', _stage_state_constructor)
 
 
-class StageState(yaml.YAMLObject):
+class StageState(State):
     yaml_tag = u'!StageState'
 
-    def __init__(self, files, directories):
+    @classmethod
+    def properties_of_interest(cls, options):
+        """Extract the properties concerning this step from the options.
+
+        The only property of interest to the stage step is the `stage` keyword
+        used to filter out files with a white or blacklist.
+        """
+
+        return {'stage': getattr(options, 'stage', ['*']) or ['*']}
+
+    def __init__(self, files, directories, options=None):
+        super().__init__(options)
+
         self.files = files
         self.directories = directories
-
-    def __repr__(self):
-        return '{}(files: {}, directories: {})'.format(
-            self.__class__, self.files, self.directories)
-
-    def __eq__(self, other):
-        if type(other) is type(self):
-            return self.__dict__ == other.__dict__
-
-        return False

--- a/snapcraft/lifecycle.py
+++ b/snapcraft/lifecycle.py
@@ -45,7 +45,7 @@ summary: # 79 char long summary
 description: # A longer description for the snap
 '''
 
-_STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'strip'}
+_STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'strip'}
 
 
 def init():

--- a/snapcraft/lifecycle.py
+++ b/snapcraft/lifecycle.py
@@ -159,6 +159,23 @@ class _Executor:
             staged_state = self.config.get_project_state('stage')
             stripped_state = self.config.get_project_state('strip')
 
+            # We need to clean this step, but if it's the stage step and it
+            # has dependents that have been built, we need to ask for them to
+            # first be cleaned (at least back to the build step).
+            dependents = self.config.part_dependents(part.name)
+            if step == 'stage' and dependents:
+                for dependent in self.config.all_parts:
+                    if (dependent.name in dependents and
+                            not dependent.is_clean('build')):
+                        humanized_parts = _humanize_list(dependents)
+
+                        raise RuntimeError(
+                            'Stage step for {0!r} needs to be run again, but '
+                            '{1} depend{2} upon it. Please clean the build '
+                            'step of {1} first.'.format(
+                                part.name, humanized_parts,
+                                's' if len(dependents) == 1 else ''))
+
             part.clean(staged_state, stripped_state, step, '(out of date)')
 
 
@@ -278,15 +295,12 @@ def _verify_dependents_will_be_cleaned(part_name, clean_part_names, step,
         for part in config.all_parts:
             if part.name in dependents and not part.is_clean(step):
                 humanized_parts = _humanize_list(dependents)
-                if len(dependents) == 1:
-                    humanized_parts += ' depends'
-                else:
-                    humanized_parts += ' depend'
 
                 raise RuntimeError(
-                    'Requested clean of {!r} but {} upon it. Please add each '
-                    "to the clean command if that's what you intended.".format(
-                        part_name, humanized_parts))
+                    'Requested clean of {!r} but {} depend{} upon it. Please '
+                    "add each to the clean command if that's what you "
+                    'intended.'.format(part_name, humanized_parts,
+                                       's' if len(dependents) == 1 else ''))
 
 
 def _clean_parts(part_names, step, config, staged_state, stripped_state):

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -256,10 +256,10 @@ class PluginHandler:
         self.mark_done('pull')
 
     def clean_pull(self, hint=''):
-        state_file = self._step_state_file('pull')
-        if not os.path.isfile(state_file):
+        if self.is_clean('pull'):
+            hint = (hint + ' (already clean)').strip()
             self.notify_part_progress('Skipping cleaning pulled source for',
-                                      '(already clean)')
+                                      hint)
             return
 
         self.notify_part_progress('Cleaning pulled source for', hint)
@@ -284,10 +284,10 @@ class PluginHandler:
         self.mark_done('build')
 
     def clean_build(self, hint=''):
-        state_file = self._step_state_file('build')
-        if not os.path.isfile(state_file):
+        if self.is_clean('build'):
+            hint = (hint + ' (already clean)').strip()
             self.notify_part_progress('Skipping cleaning build for',
-                                      '(already clean)')
+                                      hint)
             return
 
         self.notify_part_progress('Cleaning build for', hint)
@@ -331,19 +331,18 @@ class PluginHandler:
         # dependencies here too
 
         self.mark_done('stage', internal.states.StageState(
-            snap_files, snap_dirs))
+            snap_files, snap_dirs, self.code.options))
 
     def clean_stage(self, project_staged_state, hint=''):
-        state_file = self._step_state_file('stage')
-        if not os.path.isfile(state_file):
+        if self.is_clean('stage'):
+            hint = (hint + ' (already clean)').strip()
             self.notify_part_progress('Skipping cleaning staging area for',
-                                      '(already clean)')
+                                      hint)
             return
 
         self.notify_part_progress('Cleaning staging area for', hint)
 
-        with open(state_file, 'r') as f:
-            state = yaml.load(f.read())
+        state = self.get_state('stage')
 
         try:
             self._clean_shared_area(self.stagedir, state,
@@ -396,16 +395,15 @@ class PluginHandler:
             snap_files, snap_dirs, dependency_paths, self.code.options))
 
     def clean_strip(self, project_stripped_state, hint=''):
-        state_file = self._step_state_file('strip')
-        if not os.path.isfile(state_file):
+        if self.is_clean('strip'):
+            hint = (hint + ' (already clean)').strip()
             self.notify_part_progress('Skipping cleaning snapping area for',
-                                      '(already clean)')
+                                      hint)
             return
 
         self.notify_part_progress('Cleaning snapping area for', hint)
 
-        with open(state_file, 'r') as f:
-            state = yaml.load(f.read())
+        state = self.get_state('strip')
 
         try:
             self._clean_shared_area(self.snapdir, state,

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -296,7 +296,7 @@ class PluginHandler:
 
     def migratable_fileset_for(self, step):
         plugin_fileset = self.code.snap_fileset()
-        fileset = getattr(self.code.options, step, ['*']) or ['*']
+        fileset = (getattr(self.code.options, step, ['*']) or ['*']).copy()
         fileset.extend(plugin_fileset)
 
         return _migratable_filesets(fileset, self.code.installdir)

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -257,7 +257,7 @@ class PluginHandler:
 
     def clean_pull(self, hint=''):
         if self.is_clean('pull'):
-            hint = (hint + ' (already clean)').strip()
+            hint = '{} {}'.format(hint, '(already clean)').strip()
             self.notify_part_progress('Skipping cleaning pulled source for',
                                       hint)
             return
@@ -285,7 +285,7 @@ class PluginHandler:
 
     def clean_build(self, hint=''):
         if self.is_clean('build'):
-            hint = (hint + ' (already clean)').strip()
+            hint = '{} {}'.format(hint, '(already clean)').strip()
             self.notify_part_progress('Skipping cleaning build for',
                                       hint)
             return
@@ -335,7 +335,7 @@ class PluginHandler:
 
     def clean_stage(self, project_staged_state, hint=''):
         if self.is_clean('stage'):
-            hint = (hint + ' (already clean)').strip()
+            hint = '{} {}'.format(hint, '(already clean)').strip()
             self.notify_part_progress('Skipping cleaning staging area for',
                                       hint)
             return
@@ -396,7 +396,7 @@ class PluginHandler:
 
     def clean_strip(self, project_stripped_state, hint=''):
         if self.is_clean('strip'):
-            hint = (hint + ' (already clean)').strip()
+            hint = '{} {}'.format(hint, '(already clean)').strip()
             self.notify_part_progress('Skipping cleaning snapping area for',
                                       hint)
             return

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -142,9 +142,58 @@ description: test
         }
         self.assertEqual(snap_info, expected_snap_info)
 
-    def test_dirty_strip_restrips(self):
+    def test_dirty_strip_restrips_single_part(self):
         self.make_snapcraft_yaml("""parts:
   part1:
+    plugin: nil
+  part2:
+    plugin: nil
+""")
+
+        # Strip it.
+        snapcraft.lifecycle.execute('strip', self.project_options)
+
+        # Reset logging since we only care about the following
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+        def _fake_is_dirty(self, step):
+            return self.name == 'part1' and step == 'strip'
+
+        # Should automatically clean and re-strip if that step is dirty
+        # for the part.
+        with mock.patch.object(pluginhandler.PluginHandler, 'is_dirty',
+                               _fake_is_dirty):
+            snapcraft.lifecycle.execute('strip', self.project_options)
+
+        output = self.fake_logger.output.split('\n')
+        part1_output = [line.strip() for line in output if 'part1' in line]
+        part2_output = [line.strip() for line in output if 'part2' in line]
+
+        self.assertEqual(
+            [
+                'Skipping pull part2 (already ran)',
+                'Skipping build part2 (already ran)',
+                'Skipping stage part2 (already ran)',
+                'Skipping strip part2 (already ran)',
+            ],
+            part2_output)
+
+        self.assertEqual(
+            [
+                'Skipping pull part1 (already ran)',
+                'Skipping build part1 (already ran)',
+                'Skipping stage part1 (already ran)',
+                'Cleaning snapping area for part1 (out of date)',
+                'Stripping part1',
+            ],
+            part1_output)
+
+    def test_dirty_strip_restrips_multiple_part(self):
+        self.make_snapcraft_yaml("""parts:
+  part1:
+    plugin: nil
+  part2:
     plugin: nil
 """)
 
@@ -164,17 +213,82 @@ description: test
                                _fake_is_dirty):
             snapcraft.lifecycle.execute('strip', self.project_options)
 
-        self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Skipping stage part1 (already ran)\n'
-            'Cleaning snapping area for part1 (out of date)\n'
-            'Stripping part1 \n',
-            self.fake_logger.output)
+        output = self.fake_logger.output.split('\n')
+        part1_output = [line.strip() for line in output if 'part1' in line]
+        part2_output = [line.strip() for line in output if 'part2' in line]
 
-    def test_dirty_stage_restages(self):
+        self.assertEqual(
+            [
+                'Skipping pull part2 (already ran)',
+                'Skipping build part2 (already ran)',
+                'Skipping stage part2 (already ran)',
+                'Cleaning snapping area for part2 (out of date)',
+                'Stripping part2',
+            ],
+            part2_output)
+
+        self.assertEqual(
+            [
+                'Skipping pull part1 (already ran)',
+                'Skipping build part1 (already ran)',
+                'Skipping stage part1 (already ran)',
+                'Cleaning snapping area for part1 (out of date)',
+                'Stripping part1',
+            ],
+            part1_output)
+
+    def test_dirty_stage_restages_single_part(self):
         self.make_snapcraft_yaml("""parts:
   part1:
+    plugin: nil
+  part2:
+    plugin: nil
+""")
+
+        # Stage it.
+        snapcraft.lifecycle.execute('stage', self.project_options)
+
+        # Reset logging since we only care about the following
+        self.fake_logger = fixtures.FakeLogger(level=logging.INFO)
+        self.useFixture(self.fake_logger)
+
+        def _fake_is_dirty(self, step):
+            return self.name == 'part1' and step == 'stage'
+
+        # Should automatically clean and re-stage if that step is dirty
+        # for the part.
+        with mock.patch.object(pluginhandler.PluginHandler, 'is_dirty',
+                               _fake_is_dirty):
+            snapcraft.lifecycle.execute('stage', self.project_options)
+
+        output = self.fake_logger.output.split('\n')
+        part1_output = [line.strip() for line in output if 'part1' in line]
+        part2_output = [line.strip() for line in output if 'part2' in line]
+
+        self.assertEqual(
+            [
+                'Skipping pull part2 (already ran)',
+                'Skipping build part2 (already ran)',
+                'Skipping stage part2 (already ran)',
+            ],
+            part2_output)
+
+        self.assertEqual(
+            [
+                'Skipping pull part1 (already ran)',
+                'Skipping build part1 (already ran)',
+                'Skipping cleaning snapping area for part1 (out of date) '
+                '(already clean)',
+                'Cleaning staging area for part1 (out of date)',
+                'Staging part1',
+            ],
+            part1_output)
+
+    def test_dirty_stage_restages_multiple_parts(self):
+        self.make_snapcraft_yaml("""parts:
+  part1:
+    plugin: nil
+  part2:
     plugin: nil
 """)
 
@@ -194,14 +308,31 @@ description: test
                                _fake_is_dirty):
             snapcraft.lifecycle.execute('stage', self.project_options)
 
+        output = self.fake_logger.output.split('\n')
+        part1_output = [line.strip() for line in output if 'part1' in line]
+        part2_output = [line.strip() for line in output if 'part2' in line]
+
         self.assertEqual(
-            'Skipping pull part1 (already ran)\n'
-            'Skipping build part1 (already ran)\n'
-            'Skipping cleaning snapping area for part1 (out of date) '
-            '(already clean)\n'
-            'Cleaning staging area for part1 (out of date)\n'
-            'Staging part1 \n',
-            self.fake_logger.output)
+            [
+                'Skipping pull part2 (already ran)',
+                'Skipping build part2 (already ran)',
+                'Skipping cleaning snapping area for part2 (out of date) '
+                '(already clean)',
+                'Cleaning staging area for part2 (out of date)',
+                'Staging part2',
+            ],
+            part2_output)
+
+        self.assertEqual(
+            [
+                'Skipping pull part1 (already ran)',
+                'Skipping build part1 (already ran)',
+                'Skipping cleaning snapping area for part1 (out of date) '
+                '(already clean)',
+                'Cleaning staging area for part1 (out of date)',
+                'Staging part1',
+            ],
+            part1_output)
 
     def test_dirty_stage_restrips(self):
         self.make_snapcraft_yaml("""parts:

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import logging
 import os
 import shutil
@@ -64,6 +65,28 @@ class PluginTestCase(tests.TestCase):
         self.assertEqual(include, ['opt/something', 'usr/bin',
                                    '-everything', r'\a'])
         self.assertEqual(exclude, ['etc', 'usr/lib/*.a'])
+
+    @patch.object(snapcraft.plugins.nil.NilPlugin, 'snap_fileset')
+    def test_migratable_fileset_for_no_options_modification(
+            self, mock_snap_fileset):
+        """Making sure migratable_fileset_for() doesn't modify options"""
+
+        mock_snap_fileset.return_value = ['baz']
+
+        handler = pluginhandler.load_plugin('test-part', 'nil')
+        handler.code.options.snap = ['foo']
+        handler.code.options.stage = ['bar']
+        expected_options = copy.deepcopy(handler.code.options)
+
+        handler.migratable_fileset_for('stage')
+        self.assertEqual(expected_options.__dict__,
+                         handler.code.options.__dict__,
+                         'Expected options to be unmodified')
+
+        handler.migratable_fileset_for('strip')
+        self.assertEqual(expected_options.__dict__,
+                         handler.code.options.__dict__,
+                         'Expected options to be unmodified')
 
     def test_fileset_only_includes(self):
         stage_set = [

--- a/snapcraft/tests/test_states_stage.py
+++ b/snapcraft/tests/test_states_stage.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import snapcraft.internal
+from snapcraft import tests
+
+
+class StageStateTestCase(tests.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.files = {'foo'}
+        self.directories = {'bar'}
+
+        class Options:
+            def __init__(self):
+                self.stage = ['baz']
+
+        self.options = Options()
+
+        self.state = snapcraft.internal.states.StageState(
+            self.files, self.directories, self.options)
+
+    def test_representation(self):
+        expected = (
+            'StageState(directories: {}, files: {}, properties: {})').format(
+                self.directories, self.files, self.options.__dict__)
+        self.assertEqual(expected, repr(self.state))
+
+    def test_comparison(self):
+        other = snapcraft.internal.states.StageState(
+            self.files, self.directories, self.options)
+
+        self.assertTrue(self.state == other, 'Expected states to be identical')
+
+    def test_comparison_not_equal(self):
+        others = [
+            snapcraft.internal.states.StageState(set(), self.directories,
+                                                 self.options),
+            snapcraft.internal.states.StageState(self.files, set(),
+                                                 self.options),
+            snapcraft.internal.states.StageState(self.files, self.directories,
+                                                 None),
+        ]
+
+        for index, other in enumerate(others):
+            with self.subTest('other #{}'.format(index+1)):
+                self.assertFalse(self.state == other,
+                                 'Expected states to be different')


### PR DESCRIPTION
Currently Snapcraft only notices YAML changes for the strip step. For all other steps, if the step has already run it simply says so and bails. This PR makes progress on LP: [#1477904](https://bugs.launchpad.net/snapcraft/+bug/1477904) by changing that for the stage step, where now if one changes the `stage` keyword in the YAML, stage will notice that it's out of date and automatically clean itself (along with the strip step since it depends upon stage) and re-run.