### PR TITLE
Detect dirty build step.

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -163,7 +163,8 @@ class BasePlugin:
             },
             'required': [
                 'source',
-            ]
+            ],
+            'build-properties': []
         }
 
     @property

--- a/snapcraft/internal/states/__init__.py
+++ b/snapcraft/internal/states/__init__.py
@@ -16,3 +16,4 @@
 
 from snapcraft.internal.states._strip_state import StripState  # noqa
 from snapcraft.internal.states._stage_state import StageState  # noqa
+from snapcraft.internal.states._build_state import BuildState  # noqa

--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -1,4 +1,4 @@
-# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+# -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
 #
 # Copyright (C) 2016 Canonical Ltd
 #
@@ -19,32 +19,32 @@ import yaml
 from snapcraft.internal.states._state import State
 
 
-def _strip_state_constructor(loader, node):
+def _build_state_constructor(loader, node):
     parameters = loader.construct_mapping(node)
-    return StripState(**parameters)
+    return BuildState(**parameters)
 
-yaml.add_constructor(u'!StripState', _strip_state_constructor)
+yaml.add_constructor(u'!BuildState', _build_state_constructor)
 
 
-class StripState(State):
-    yaml_tag = u'!StripState'
+class BuildState(State):
+    yaml_tag = u'!BuildState'
 
-    def __init__(self, files, directories, dependency_paths=None,
-                 options=None):
+    def __init__(self, schema_properties, options=None):
+        # Save this off before calling super() since we'll need it
+        self.schema_properties = schema_properties
+
         super().__init__(options)
-
-        self.files = files
-        self.directories = directories
-        self.dependency_paths = set()
-
-        if dependency_paths:
-            self.dependency_paths = dependency_paths
 
     def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
 
-        The only property of interest to the strip step is the `snap` keyword
-        used to filter out files with a white or blacklist.
+        The properties of interest to the build step vary depending on the
+        plugin, so we use self.schema_properties.
         """
 
-        return {'snap': getattr(options, 'snap', ['*']) or ['*']}
+        properties = {}
+        for schema_property in self.schema_properties:
+            properties[schema_property] = getattr(options, schema_property,
+                                                  None)
+
+        return properties

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -29,8 +29,13 @@ yaml.add_constructor(u'!StageState', _stage_state_constructor)
 class StageState(State):
     yaml_tag = u'!StageState'
 
-    @classmethod
-    def properties_of_interest(cls, options):
+    def __init__(self, files, directories, options=None):
+        super().__init__(options)
+
+        self.files = files
+        self.directories = directories
+
+    def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
 
         The only property of interest to the stage step is the `stage` keyword
@@ -38,9 +43,3 @@ class StageState(State):
         """
 
         return {'stage': getattr(options, 'stage', ['*']) or ['*']}
-
-    def __init__(self, files, directories, options=None):
-        super().__init__(options)
-
-        self.files = files
-        self.directories = directories

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -18,17 +18,16 @@ import yaml
 
 
 class State(yaml.YAMLObject):
-    @classmethod
-    def properties_of_interest(cls, options):
+    def __init__(self, options):
+        self.properties = self.properties_of_interest(options)
+
+    def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
 
         Note that these options come from the YAML for a given part.
         """
 
         raise NotImplementedError
-
-    def __init__(self, options):
-        self.properties = self.properties_of_interest(options)
 
     def __repr__(self):
         items = sorted(self.__dict__.items())

--- a/snapcraft/plugins/autotools.py
+++ b/snapcraft/plugins/autotools.py
@@ -65,6 +65,10 @@ class AutotoolsPlugin(snapcraft.BasePlugin):
             'default': 'destdir',
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(['configflags', 'install-via'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/cmake.py
+++ b/snapcraft/plugins/cmake.py
@@ -51,6 +51,10 @@ class CMakePlugin(snapcraft.plugins.make.MakePlugin):
             'default': [],
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].append('configflags')
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/copy.py
+++ b/snapcraft/plugins/copy.py
@@ -53,6 +53,10 @@ class CopyPlugin(snapcraft.BasePlugin):
             'type': 'object',
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].append('files')
+
         # The `files` keyword is required here, but the `source` keyword is
         # not. It should default to the current working directory.
         schema['required'].append('files')

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -57,6 +57,10 @@ class GoPlugin(snapcraft.BasePlugin):
         if 'required' in schema:
             del schema['required']
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(['source', 'go-packages'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/kbuild.py
+++ b/snapcraft/plugins/kbuild.py
@@ -92,6 +92,11 @@ class KBuildPlugin(BasePlugin):
             'default': [],
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(['kdefconfig', 'kconfigfile',
+                                           'kconfigs'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -122,6 +122,13 @@ class KernelPlugin(kbuild.KBuildPlugin):
             'enum': ['gz'],
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend([
+            'kernel-image-target', 'kernel-with-firmware',
+            'kernel-initrd-modules', 'kernel-initrd-firmware',
+            'kernel-device-trees', 'kernel-initrd-compression'])
+
         return schema
 
     @property

--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -44,7 +44,7 @@ class MakePlugin(snapcraft.BasePlugin):
     def schema(cls):
         schema = super().schema()
         schema['properties']['makefile'] = {
-            'type': 'string'
+            'type': 'string',
         }
         schema['properties']['make-parameters'] = {
             'type': 'array',
@@ -55,6 +55,10 @@ class MakePlugin(snapcraft.BasePlugin):
             },
             'default': [],
         }
+
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(['makefile', 'make-parameters'])
 
         return schema
 

--- a/snapcraft/plugins/maven.py
+++ b/snapcraft/plugins/maven.py
@@ -78,6 +78,10 @@ class MavenPlugin(snapcraft.plugins.jdk.JdkPlugin):
             'default': [],
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].append('maven-options')
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/nodejs.py
+++ b/snapcraft/plugins/nodejs.py
@@ -69,6 +69,10 @@ class NodePlugin(snapcraft.BasePlugin):
         if 'required' in schema:
             del schema['required']
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].append('node-packages')
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/scons.py
+++ b/snapcraft/plugins/scons.py
@@ -49,6 +49,10 @@ class SconsPlugin(snapcraft.BasePlugin):
             'default': []
         }
 
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].append('scons-options')
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/tar_content.py
+++ b/snapcraft/plugins/tar_content.py
@@ -39,6 +39,12 @@ class TarContentPlugin(snapcraft.BasePlugin):
             },
             'required': [
                 'source',
+            ],
+            # Inform Snapcraft of the properties associated with building. If
+            # these change in the YAML Snapcraft will consider the build step
+            # dirty.
+            'build-properties': [
+                'destination'
             ]
         }
 

--- a/snapcraft/tests/test_plugin_autotools.py
+++ b/snapcraft/tests/test_plugin_autotools.py
@@ -101,6 +101,13 @@ class AutotoolsPluginTestCase(tests.TestCase):
                          'Expected "install-via" "default" to be "destdir", '
                          'but it was "{}"'.format(installvia_default))
 
+        self.assertTrue('build-properties' in schema,
+                        'Expected schema to include "build-properties"')
+        build_properties = schema['build-properties']
+        self.assertEqual(2, len(build_properties))
+        self.assertTrue('configflags' in build_properties)
+        self.assertTrue('install-via' in build_properties)
+
     def test_install_via_invalid_enum(self):
         self.options.install_via = 'invalid'
         with self.assertRaises(RuntimeError) as raised:

--- a/snapcraft/tests/test_plugin_kbuild.py
+++ b/snapcraft/tests/test_plugin_kbuild.py
@@ -59,6 +59,12 @@ class KBuildPluginTestCase(tests.TestCase):
         self.assertEqual(properties['kconfigs']['items']['type'], 'string')
         self.assertTrue(properties['kconfigs']['uniqueItems'])
 
+        build_properties = schema['build-properties']
+        self.assertEqual(3, len(build_properties))
+        self.assertTrue('kdefconfig' in build_properties)
+        self.assertTrue('kconfigfile' in build_properties)
+        self.assertTrue('kconfigs' in build_properties)
+
     @mock.patch('subprocess.check_call')
     @mock.patch.object(kbuild.KBuildPlugin, 'run')
     def test_build_with_kconfigfile(self, run_mock, check_call_mock):

--- a/snapcraft/tests/test_plugin_kernel.py
+++ b/snapcraft/tests/test_plugin_kernel.py
@@ -108,6 +108,18 @@ class KernelPluginTestCase(tests.TestCase):
         self.assertEqual(
             properties['kernel-initrd-compression']['enum'], ['gz'])
 
+        build_properties = schema['build-properties']
+        self.assertEqual(9, len(build_properties))
+        self.assertTrue('kdefconfig' in build_properties)
+        self.assertTrue('kconfigfile' in build_properties)
+        self.assertTrue('kconfigs' in build_properties)
+        self.assertTrue('kernel-image-target' in build_properties)
+        self.assertTrue('kernel-with-firmware' in build_properties)
+        self.assertTrue('kernel-initrd-modules' in build_properties)
+        self.assertTrue('kernel-initrd-firmware' in build_properties)
+        self.assertTrue('kernel-device-trees' in build_properties)
+        self.assertTrue('kernel-initrd-compression' in build_properties)
+
     def _assert_generic_check_call(self, builddir, installdir, os_snap_path):
         self.assertEqual(4, self.check_call_mock.call_count)
         self.check_call_mock.assert_has_calls([

--- a/snapcraft/tests/test_plugin_make.py
+++ b/snapcraft/tests/test_plugin_make.py
@@ -68,6 +68,11 @@ class MakePluginTestCase(tests.TestCase):
             'Expected "make-parameters" "type" to be "array", but it '
             'was "{}"'.format(make_parameters_type))
 
+        build_properties = schema['build-properties']
+        self.assertEqual(2, len(build_properties))
+        self.assertTrue('makefile' in build_properties)
+        self.assertTrue('make-parameters' in build_properties)
+
     @mock.patch.object(make.MakePlugin, 'run')
     def test_build(self, run_mock):
         plugin = make.MakePlugin('test-part', self.options,

--- a/snapcraft/tests/test_plugin_maven.py
+++ b/snapcraft/tests/test_plugin_maven.py
@@ -70,6 +70,9 @@ class MavenPluginTestCase(tests.TestCase):
             maven_options['uniqueItems'],
             'Expected "maven-options" "uniqueItems" to be "True"')
 
+        build_properties = schema['build-properties']
+        self.assertEqual(['maven-options'], build_properties)
+
     @mock.patch.object(maven.MavenPlugin, 'run')
     @mock.patch('glob.glob')
     def test_build(self, glob_mock, run_mock):

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -136,13 +136,14 @@ class NodePluginTestCase(tests.TestCase):
                 'source-subdir': {'default': None, 'type': 'string'},
                 'source-tag': {'default': '', 'type:': 'string'},
                 'source-type': {'default': '', 'type': 'string'}},
+            'build-properties': ['node-packages'],
             'type': 'object'}
 
         self.assertEqual(nodejs.NodePlugin.schema(), plugin_schema)
 
     @mock.patch('snapcraft.BasePlugin.schema')
     def test_required_not_in_parent_schema(self, schema_mock):
-        schema_mock.return_value = {'properties': {}}
+        schema_mock.return_value = {'properties': {}, 'build-properties': []}
 
         self.assertTrue('required' not in nodejs.NodePlugin.schema())
 

--- a/snapcraft/tests/test_states_build.py
+++ b/snapcraft/tests/test_states_build.py
@@ -1,0 +1,56 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import snapcraft.internal
+from snapcraft import tests
+
+
+class BuildStateTestCase(tests.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.schema_properties = ['foo']
+
+        class Options:
+            def __init__(self):
+                self.foo = ['bar']
+
+        self.options = Options()
+
+        self.state = snapcraft.internal.states.BuildState(
+            self.schema_properties, self.options)
+
+    def test_representation(self):
+        expected = 'BuildState(properties: {}, schema_properties: {})'.format(
+            self.options.__dict__, self.schema_properties)
+        self.assertEqual(expected, repr(self.state))
+
+    def test_comparison(self):
+        other = snapcraft.internal.states.BuildState(
+            self.schema_properties, self.options)
+
+        self.assertTrue(self.state == other, 'Expected states to be identical')
+
+    def test_comparison_not_equal(self):
+        others = [
+            snapcraft.internal.states.BuildState([], self.options),
+            snapcraft.internal.states.BuildState(self.schema_properties, None)
+        ]
+
+        for index, other in enumerate(others):
+            with self.subTest('other #{}'.format(index+1)):
+                self.assertFalse(self.state == other,
+                                 'Expected states to be different')


### PR DESCRIPTION
Currently Snapcraft notices YAML changes only for the strip and stage steps. For the other steps, if they've already run, it simply says so and bails. This PR makes progress on LP: [#1477904](https://bugs.launchpad.net/snapcraft/+bug/1477904) by changing that for the build step, where now if one changes any part of the YAML that the part's plugin says is associated with building, build will notice that it's out of date and error out asking the user to clean the build step to continue.

The build step is not automatically cleaned like the strip and stage steps because builds can take a very long time and we don't want to blow one away without the user explicitly asking to do so.