### PR TITLE
Detect dirty pull step.

### DIFF
--- a/snapcraft/__init__.py
+++ b/snapcraft/__init__.py
@@ -164,6 +164,8 @@ class BasePlugin:
             'required': [
                 'source',
             ],
+            'pull-properties': ['source', 'source-type', 'source-branch',
+                                'source-tag', 'source-subdir'],
             'build-properties': []
         }
 

--- a/snapcraft/internal/states/__init__.py
+++ b/snapcraft/internal/states/__init__.py
@@ -17,3 +17,4 @@
 from snapcraft.internal.states._strip_state import StripState  # noqa
 from snapcraft.internal.states._stage_state import StageState  # noqa
 from snapcraft.internal.states._build_state import BuildState  # noqa
+from snapcraft.internal.states._pull_state import PullState  # noqa

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+
+from snapcraft.internal.states._state import State
+
+
+def _pull_state_constructor(loader, node):
+    parameters = loader.construct_mapping(node)
+    return PullState(**parameters)
+
+yaml.add_constructor(u'!PullState', _pull_state_constructor)
+
+
+class PullState(State):
+    yaml_tag = u'!PullState'
+
+    def __init__(self, schema_properties, options=None):
+        # Save this off before calling super() since we'll need it
+        self.schema_properties = schema_properties
+
+        super().__init__(options)
+
+    def properties_of_interest(self, options):
+        """Extract the properties concerning this step from the options.
+
+        The properties of interest to the pull step vary depending on the
+        plugin, so we use self.schema_properties.
+        """
+
+        properties = {}
+        for schema_property in self.schema_properties:
+            properties[schema_property] = getattr(options, schema_property,
+                                                  None)
+
+        return properties

--- a/snapcraft/lifecycle.py
+++ b/snapcraft/lifecycle.py
@@ -160,8 +160,8 @@ class _Executor:
     def _handle_dirty(self, part, step):
         if step not in _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY:
             raise RuntimeError(
-                'The {!r} step of {!r} is out of date. Please clean that '
-                "part's build step in order to rebuild".format(
+                'The {0!r} step of {1!r} is out of date. Please clean that '
+                "part's {0!r} step in order to rebuild".format(
                     step, part.name))
 
         staged_state = self.config.get_project_state('stage')

--- a/snapcraft/pluginhandler.py
+++ b/snapcraft/pluginhandler.py
@@ -257,7 +257,8 @@ class PluginHandler:
         self.makedirs()
         self.notify_part_progress('Pulling')
         self.code.pull()
-        self.mark_done('pull')
+        self.mark_done('pull', internal.states.PullState(
+            self.pull_properties, self.code.options))
 
     def clean_pull(self, hint=''):
         if self.is_clean('pull'):

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -91,6 +91,12 @@ deb http://${security}.ubuntu.com/${suffix} trusty-security main universe
 
         schema['required'].append('catkin-packages')
 
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        schema['pull-properties'].extend(
+            ['rosdistro', 'catkin-packages', 'source-space',
+             'include-roscore'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/go.py
+++ b/snapcraft/plugins/go.py
@@ -57,6 +57,10 @@ class GoPlugin(snapcraft.BasePlugin):
         if 'required' in schema:
             del schema['required']
 
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        schema['pull-properties'].append('go-packages')
+
         # Inform Snapcraft of the properties associated with building. If these
         # change in the YAML Snapcraft will consider the build step dirty.
         schema['build-properties'].extend(['source', 'go-packages'])

--- a/snapcraft/plugins/python2.py
+++ b/snapcraft/plugins/python2.py
@@ -66,6 +66,10 @@ class Python2Plugin(snapcraft.BasePlugin):
         }
         schema.pop('required')
 
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        schema['pull-properties'].extend(['requirements', 'python-packages'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/python3.py
+++ b/snapcraft/plugins/python3.py
@@ -61,6 +61,10 @@ class Python3Plugin(snapcraft.BasePlugin):
         }
         schema.pop('required')
 
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        schema['pull-properties'].extend(['requirements', 'python-packages'])
+
         return schema
 
     def __init__(self, name, options, project):

--- a/snapcraft/plugins/tar_content.py
+++ b/snapcraft/plugins/tar_content.py
@@ -40,6 +40,12 @@ class TarContentPlugin(snapcraft.BasePlugin):
             'required': [
                 'source',
             ],
+            # Inform Snapcraft of the properties associated with pulling. If
+            # these change in the YAML Snapcraft will consider the pull step
+            # dirty.
+            'pull-properties': [
+                'source'
+            ],
             # Inform Snapcraft of the properties associated with building. If
             # these change in the YAML Snapcraft will consider the build step
             # dirty.

--- a/snapcraft/tests/test_plugin_catkin.py
+++ b/snapcraft/tests/test_plugin_catkin.py
@@ -201,6 +201,15 @@ class CatkinPluginTestCase(tests.TestCase):
                         'Expected "catkin-packages" to be included in '
                         '"required"')
 
+        # Check pull-properties
+        self.assertTrue('pull-properties' in schema,
+                        'Expected schema to include "pull-properties"')
+        pull_properties = schema['pull-properties']
+        self.assertTrue('rosdistro' in pull_properties)
+        self.assertTrue('catkin-packages' in pull_properties)
+        self.assertTrue('source-space' in pull_properties)
+        self.assertTrue('include-roscore' in pull_properties)
+
     def test_pull_debian_dependencies(self):
         plugin = catkin.CatkinPlugin('test-part', self.properties,
                                      self.project_options)

--- a/snapcraft/tests/test_plugin_nodejs.py
+++ b/snapcraft/tests/test_plugin_nodejs.py
@@ -136,6 +136,8 @@ class NodePluginTestCase(tests.TestCase):
                 'source-subdir': {'default': None, 'type': 'string'},
                 'source-tag': {'default': '', 'type:': 'string'},
                 'source-type': {'default': '', 'type': 'string'}},
+            'pull-properties': ['source', 'source-type', 'source-branch',
+                                'source-tag', 'source-subdir'],
             'build-properties': ['node-packages'],
             'type': 'object'}
 
@@ -143,7 +145,11 @@ class NodePluginTestCase(tests.TestCase):
 
     @mock.patch('snapcraft.BasePlugin.schema')
     def test_required_not_in_parent_schema(self, schema_mock):
-        schema_mock.return_value = {'properties': {}, 'build-properties': []}
+        schema_mock.return_value = {
+            'properties': {},
+            'pull-properties': [],
+            'build-properties': []
+        }
 
         self.assertTrue('required' not in nodejs.NodePlugin.schema())
 


### PR DESCRIPTION
Currently Snapcraft notices YAML changes for every step except the pull step.This PR finishes up LP: [#1477904](https://bugs.launchpad.net/snapcraft/+bug/1477904) by adding this functionality for the pull step, where now if one changes any part of the YAML that the part's plugin says is associated with pulling, pull will notice that it's out of date and error out asking the user to clean the pull step to continue.

The pull step is not automatically cleaned like the strip and stage steps because pulls can take a very long time (and require network) and we don't want to blow one away without the user explicitly asking to do so.