### PR TITLE
Make pull and build steps dirty if target arch changes.

### DIFF
--- a/snapcraft/internal/states/_build_state.py
+++ b/snapcraft/internal/states/_build_state.py
@@ -29,11 +29,11 @@ yaml.add_constructor(u'!BuildState', _build_state_constructor)
 class BuildState(State):
     yaml_tag = u'!BuildState'
 
-    def __init__(self, schema_properties, options=None):
+    def __init__(self, schema_properties, options=None, project=None):
         # Save this off before calling super() since we'll need it
         self.schema_properties = schema_properties
 
-        super().__init__(options)
+        super().__init__(options, project)
 
     def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
@@ -48,3 +48,11 @@ class BuildState(State):
                                                   None)
 
         return properties
+
+    def project_options_of_interest(self, project):
+        """Extract the options concerning this step from the project.
+
+        The build step only cares about the target architecture.
+        """
+
+        return {'deb_arch': getattr(project, 'deb_arch', None)}

--- a/snapcraft/internal/states/_pull_state.py
+++ b/snapcraft/internal/states/_pull_state.py
@@ -29,11 +29,11 @@ yaml.add_constructor(u'!PullState', _pull_state_constructor)
 class PullState(State):
     yaml_tag = u'!PullState'
 
-    def __init__(self, schema_properties, options=None):
+    def __init__(self, schema_properties, options=None, project=None):
         # Save this off before calling super() since we'll need it
         self.schema_properties = schema_properties
 
-        super().__init__(options)
+        super().__init__(options, project)
 
     def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
@@ -48,3 +48,11 @@ class PullState(State):
                                                   None)
 
         return properties
+
+    def project_options_of_interest(self, project):
+        """Extract the options concerning this step from the project.
+
+        The pull step only cares about the target architecture.
+        """
+
+        return {'deb_arch': getattr(project, 'deb_arch', None)}

--- a/snapcraft/internal/states/_stage_state.py
+++ b/snapcraft/internal/states/_stage_state.py
@@ -29,8 +29,8 @@ yaml.add_constructor(u'!StageState', _stage_state_constructor)
 class StageState(State):
     yaml_tag = u'!StageState'
 
-    def __init__(self, files, directories, options=None):
-        super().__init__(options)
+    def __init__(self, files, directories, options=None, project=None):
+        super().__init__(options, project)
 
         self.files = files
         self.directories = directories
@@ -43,3 +43,11 @@ class StageState(State):
         """
 
         return {'stage': getattr(options, 'stage', ['*']) or ['*']}
+
+    def project_options_of_interest(self, project):
+        """Extract the options concerning this step from the project.
+
+        The stage step doesn't care about any project options.
+        """
+
+        return {}

--- a/snapcraft/internal/states/_state.py
+++ b/snapcraft/internal/states/_state.py
@@ -18,14 +18,20 @@ import yaml
 
 
 class State(yaml.YAMLObject):
-    def __init__(self, options):
+    def __init__(self, options, project):
         self.properties = self.properties_of_interest(options)
+        self.project_options = self.project_options_of_interest(project)
 
     def properties_of_interest(self, options):
         """Extract the properties concerning this step from the options.
 
         Note that these options come from the YAML for a given part.
         """
+
+        raise NotImplementedError
+
+    def project_options_of_interest(self, project):
+        """Extract the options concerning this step from the project."""
 
         raise NotImplementedError
 

--- a/snapcraft/internal/states/_strip_state.py
+++ b/snapcraft/internal/states/_strip_state.py
@@ -30,8 +30,8 @@ class StripState(State):
     yaml_tag = u'!StripState'
 
     def __init__(self, files, directories, dependency_paths=None,
-                 options=None):
-        super().__init__(options)
+                 options=None, project=None):
+        super().__init__(options, project)
 
         self.files = files
         self.directories = directories
@@ -48,3 +48,11 @@ class StripState(State):
         """
 
         return {'snap': getattr(options, 'snap', ['*']) or ['*']}
+
+    def project_options_of_interest(self, project):
+        """Extract the options concerning this step from the project.
+
+        The strip step doesn't care about any project options.
+        """
+
+        return {}

--- a/snapcraft/tests/test_states_build.py
+++ b/snapcraft/tests/test_states_build.py
@@ -30,24 +30,36 @@ class BuildStateTestCase(tests.TestCase):
 
         self.options = Options()
 
+        class Project:
+            def __init__(self):
+                self.deb_arch = 'amd64'
+
+        self.project = Project()
+
         self.state = snapcraft.internal.states.BuildState(
-            self.schema_properties, self.options)
+            self.schema_properties, self.options, self.project)
 
     def test_representation(self):
-        expected = 'BuildState(properties: {}, schema_properties: {})'.format(
-            self.options.__dict__, self.schema_properties)
+        expected = ('BuildState(project_options: {}, properties: {}, '
+                    'schema_properties: {})').format(
+            self.project.__dict__, self.options.__dict__,
+            self.schema_properties)
         self.assertEqual(expected, repr(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.BuildState(
-            self.schema_properties, self.options)
+            self.schema_properties, self.options, self.project)
 
         self.assertTrue(self.state == other, 'Expected states to be identical')
 
     def test_comparison_not_equal(self):
         others = [
-            snapcraft.internal.states.BuildState([], self.options),
-            snapcraft.internal.states.BuildState(self.schema_properties, None)
+            snapcraft.internal.states.BuildState(
+                [], self.options, self.project),
+            snapcraft.internal.states.BuildState(
+                self.schema_properties, None, self.project),
+            snapcraft.internal.states.BuildState(
+                self.schema_properties, self.options, None)
         ]
 
         for index, other in enumerate(others):

--- a/snapcraft/tests/test_states_pull.py
+++ b/snapcraft/tests/test_states_pull.py
@@ -18,57 +18,48 @@ import snapcraft.internal
 from snapcraft import tests
 
 
-class StripStateTestCase(tests.TestCase):
+class PullStateTestCase(tests.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.files = {'foo'}
-        self.directories = {'bar'}
-        self.dependency_paths = {'baz'}
+        self.schema_properties = ['foo']
 
         class Options:
             def __init__(self):
-                self.snap = ['qux']
+                self.foo = ['bar']
 
         self.options = Options()
 
         class Project:
-            pass
+            def __init__(self):
+                self.deb_arch = 'amd64'
 
         self.project = Project()
 
-        self.state = snapcraft.internal.states.StripState(
-            self.files, self.directories, self.dependency_paths, self.options,
-            self.project)
+        self.state = snapcraft.internal.states.PullState(
+            self.schema_properties, self.options, self.project)
 
     def test_representation(self):
-        expected = ('StripState(dependency_paths: {}, directories: {}, '
-                    'files: {}, project_options: {}, properties: {})').format(
-            self.dependency_paths, self.directories, self.files,
-            self.project.__dict__, self.options.__dict__)
+        expected = ('PullState(project_options: {}, properties: {}, '
+                    'schema_properties: {})').format(
+            self.project.__dict__, self.options.__dict__,
+            self.schema_properties)
         self.assertEqual(expected, repr(self.state))
 
     def test_comparison(self):
-        other = snapcraft.internal.states.StripState(
-            self.files, self.directories, self.dependency_paths, self.options,
-            self.project)
+        other = snapcraft.internal.states.PullState(
+            self.schema_properties, self.options, self.project)
 
         self.assertTrue(self.state == other, 'Expected states to be identical')
 
     def test_comparison_not_equal(self):
         others = [
-            snapcraft.internal.states.StripState(
-                set(), self.directories, self.dependency_paths,
-                self.options, self.project),
-            snapcraft.internal.states.StripState(
-                self.files, set(), self.dependency_paths,
-                self.options, self.project),
-            snapcraft.internal.states.StripState(
-                self.files, self.directories, set(),
-                self.options, self.project),
-            snapcraft.internal.states.StripState(
-                self.files, self.directories, self.dependency_paths,
-                None, self.project)
+            snapcraft.internal.states.PullState(
+                [], self.options, self.project),
+            snapcraft.internal.states.PullState(
+                self.schema_properties, None, self.project),
+            snapcraft.internal.states.PullState(
+                self.schema_properties, self.options, None)
         ]
 
         for index, other in enumerate(others):

--- a/snapcraft/tests/test_states_stage.py
+++ b/snapcraft/tests/test_states_stage.py
@@ -31,29 +31,35 @@ class StageStateTestCase(tests.TestCase):
 
         self.options = Options()
 
+        class Project:
+            pass
+
+        self.project = Project()
+
         self.state = snapcraft.internal.states.StageState(
-            self.files, self.directories, self.options)
+            self.files, self.directories, self.options, self.project)
 
     def test_representation(self):
-        expected = (
-            'StageState(directories: {}, files: {}, properties: {})').format(
-                self.directories, self.files, self.options.__dict__)
+        expected = ('StageState(directories: {}, files: {}, '
+                    'project_options: {}, properties: {})').format(
+            self.directories, self.files, self.project.__dict__,
+            self.options.__dict__)
         self.assertEqual(expected, repr(self.state))
 
     def test_comparison(self):
         other = snapcraft.internal.states.StageState(
-            self.files, self.directories, self.options)
+            self.files, self.directories, self.options, self.project)
 
         self.assertTrue(self.state == other, 'Expected states to be identical')
 
     def test_comparison_not_equal(self):
         others = [
             snapcraft.internal.states.StageState(set(), self.directories,
-                                                 self.options),
+                                                 self.options, self.project),
             snapcraft.internal.states.StageState(self.files, set(),
-                                                 self.options),
+                                                 self.options, self.project),
             snapcraft.internal.states.StageState(self.files, self.directories,
-                                                 None),
+                                                 None, self.project),
         ]
 
         for index, other in enumerate(others):


### PR DESCRIPTION
This PR fixes LP: [#1564192](https://bugs.launchpad.net/snapcraft/+bug/1564192) by tracking the target architecture and making the `pull` and `build` steps dirty if they change between runs. This was done in an extensible way so utilizing more project options in the state tracking would be easy.