### PR TITLE
docs/get-started.md: Stop discussing snappy-tools.

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -76,7 +76,7 @@ is allowed to write to.
 ## Testing a service
 
 To test a service it must be installed first. See the section "Testing a binary"
-for the various ways to do that. Once it is installed systemd's `systemctl`
+for the various ways to do that. Once it is installed, systemd's `systemctl`
 command can be used to see if the service starts and runs as expected, for
 example:
 
@@ -176,7 +176,7 @@ The most common culprits for sandbox issues are:
       app to write to `$SNAP_DATA/run` or `$SNAP_DATA/log`
       or similar
     * improperly evaluating or typoing `SNAP_` variables so the program
-      uses the wrong path. Eg, using `$SNAP_DATA/foo` instead of
+      uses the wrong path. For example, using `$SNAP_DATA/foo` instead of
       `$SNAP/foo` (`SNAP_DATA` is non-existent so it would evaluate to
       `/foo` which is disallowed by security policy)
     * hard coded paths in the program. The program should be adjusted ideally
@@ -184,8 +184,8 @@ The most common culprits for sandbox issues are:
 * Attempting to read files outside of `SNAP`, `SNAP_DATA` and
   `SNAP_USER_DATA`. This usually happens if your program is looking for
   something that isn't shipped by your snap or it is trying to look for it in
-  the wrong place (eg, typing a `SNAP_` variable, evaluating `PATH` or hardcoded
-  path). Fixes are similar to the above.
+  the wrong place (e.g., typing a `SNAP_` variable, evaluating `PATH` or
+  hardcoded path). Fixes are similar to the above.
 * Attempting to use `/var/tmp`'. The program should be adjusted to use
   `TMPDIR` or `/tmp`
 * Attempting to use `/run`. The program should be adjusted to use
@@ -204,16 +204,16 @@ The most common culprits for sandbox issues are:
   launcher to setup the sandbox, and apps aren't allowed to change their
   sandbox once they start)
 * A snap uses `setuid`/`setgid` or `chown` family of syscalls. Ubuntu Core
-  16 does not provide a mechanism of assigning users and groups to snaps, so the
-  `setuid`/`setgid` and `chown` family of syscalls are blocked (since there is
-  no appropriate user to change to. Optionally assigning users/groups to snaps
-  is a planned feature). For example,
+  16 does not provide a mechanism for assigning users and groups to snaps, so
+  the `setuid`/`setgid` and `chown` family of syscalls are blocked (since there
+  is no appropriate user to change to. Optionally assigning users/groups to
+  snaps is a planned feature). For example,
     * sometimes an existing application is designed to start as root and drop
       privileges to an unprivileged user (e.g., to bind to a port). This
       application will need to be adjusted to not drop privileges (at least
       until Ubuntu Core supports it)
     * the developer is trying to copy files from `SNAP` to
-      `SNAP_DATA` (eg, for write access of a configuration files) and
+      `SNAP_DATA` (e.g., for write access of a configuration files) and
       attempts to use a `cp -a`. This results in a `seccomp` failure when the
       command is run as root because '-a' attempts to copy the ownership
       (`chown`) of the files in `SNAP`, but these are owned by an
@@ -238,7 +238,7 @@ The most common culprits for sandbox issues are:
       security policy. Use `snappy config ubuntu-core` and add/adjust the
       `load-kernel-modules` line accordingly when developing your snap. When
       ready for production with a gadget snap, make sure the modules you need
-      are loaded there. Eg:
+      are loaded there. For example:
       ```yaml
       config:
         ubuntu-core:

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -8,15 +8,12 @@ different from more traditional systems.
 To enable coredumps for the 'hello-word' snap (version 1.0.18) run the
 following command:
 
-```
-$ sudo -s
-# ulimit -c unlimited
-# echo "/home/ubuntu/snap/hello-world.canonical/1.0.18/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
-```
+    $ ulimit -c unlimited
+    $ echo "$HOME/snap/hello-world.canonical/<revision>/core.%e.%p.%h.%t" | sudo tee /proc/sys/kernel/core_pattern > /dev/null
 
 Make sure you substitute the pattern above with the right snap name and
-version for the snap you want to inspect. Note that the apparmor profile will
-be taken into account, the segfault can only be written to places that the
+revision for the snap you want to inspect. Note that the apparmor profile will
+be taken into account, i.e. the segfault can only be written to places that the
 snap can write to.
 
 You can customize the core dump pattern with the following options
@@ -29,102 +26,6 @@ You can customize the core dump pattern with the following options
     %h: hostname
     %e: executable filename
 
-## Debugging tools
-
-There is a debug snap that can be installed with:
-
-    $ sudo snap install snappy-debug
-
-As of 2016-01-26, the snappy-debug snap only contains the
-**snappy-debug.security** tool for working with snappy security policy.
-
-*Note:* It is planned to add the following debugging tools:
-
-* `snappy-debug.gdb`: a source-level debugger
-* `snappy-debug.strace`: a syscall call tracer
-* `snappy-debug.ltrace`: a library call tracer
-
-This document will explain `gdb`, `strace`, `ltrace` even though they are not
-available as part of the package yet, because they are generally useful for
-debugging.
-
-The reason to put these tools in a snap separate from the base image was
-because they are not needed on production devices.
-
-
-### gdb
-
-The gdb debugger is useful to debug crashes of application or libraries
-written in compiled languages. In order to get most out of gdb you should
-build your application with debug symbols. If you are using the gcc compiler,
-it is recommended to do the debug builds with the following
-'CFLAGS= "-g3 -O0"'. This will enable full debug symbols and disable all
-optimizations.
-
-The most important commands for debugging with the gdb debugger are the
-`break`, `next` , `run` and `backtrace` commands. The gdb debugger supports a
- whole range of commands and options that are out of scope for this manual.
-
-To launch `gdb` run it with the program or the coredump as the first argument.
-
-The `break` command can be used to set a breakpoint to a specific line in the
-program. An example could be `(gdb) break lala.c:2`. To start running the
-program, use the `run` command. The program will stop once it reaches that
-line and can be traced with the `step` and `next` commands. Alternatively the
-operation of the program can be resumed via the `continue` command. If the
-program crashes gdb will stop and the `backtrace` command can be used to
-inspect what happened before the program crashed.
-
-Here is an example session:
-
-```
-snappy-debug.gdb application --args additional arguments
-(gdb) run
-Program received signal SIGSEGV, Segmentation fault.
-0x000000000040053f in main () at lala.c:4
-4        printf("%i", *(int*)0);
-(gdb) backtrace
-#0  0x000000000040053f in main () at lala.c:4
-```
-
-### strace
-
-The strace tool can be used to inspect what system calls an application
-performs.
-
-The command output looks like this:
-
-```
-$ snappy-debug.strace cat /etc/shadow
-...
-open("/etc/shadow", O_RDONLY)           = -1 EACCES (Permission denied)
-...
-```
-
-This indicates that the open system call failed with the given error number.
-
-### ltrace
-
-The ltrace tool is similar to strace. The difference is that it tracks
-library calls instead of system calls.
-
-The command output looks like this:
-
-```
-$ snappy-debug.ltrace /etc/shadow
-__libc_start_main(0x401a40, 2, 0x7ffc27e9f058, 0x408b40 <unfinished ...>
-getpagesize()                                    = 4096
-strrchr("cat", '/')                              = nil
-setlocale(LC_ALL, "")                            = "en_US.UTF-8"
-bindtextdomain("coreutils", "/usr/share/locale") = "/usr/share/locale"
-textdomain("coreutils")                          = "coreutils"
-__cxa_atexit(0x402ac0, 0, 0, 0x736c6974756572)   = 0
-getopt_long(2, 0x7ffc27e9f058, "benstuvAET", 0x409280, nil) = -1
-__fxstat(1, 1, 0x7ffc27e9eea0)                   = 0
-open("/etc/shadow", 0, 0400000)                  = -1
-__errno_location()                               = 0x7f1ed2527690
-```
-
 ## Important system logs
 
 Snappy Ubuntu system logs are mapped to the classic location of those logs.
@@ -136,14 +37,14 @@ The syslog is particularly useful since kernel logs, launcher output, service
 status, system logs and confinement violations (these are covered in depth
 elsewhere) all get logged there.
 
-
 ## Debugging binaries
 
 ### Installing binaries
 In order to test a new snap on a Snap-based system you need to install it first.
-This is called "sideloading" and it can be done with:
+Installing a local snap like this (as opposed to installing a snap from the
+store) is called "sideloading" and it can be done with:
 
-    sudo snap install <local-file.snap>
+    $ sudo snap install <local-file.snap>
 
 ### Binary names on CLI
 
@@ -154,33 +55,23 @@ on disk will be called `pastebinit.pastebinit`.
 
 ### Find a binary in the file system hierarchy
 
-All binary names can be found in `/snaps/bin/`. The `snap` tool will generate
-a small wrapper script that ensures that the binary in the snap is called with
+All binary names can be found in `/snap/bin/`. The `snap` tool will generate
+a small launcher script that ensures that the binary in the snap is called with
 the right confinement and environment.
 
 ### Testing if a binary is running
-After a snap is installed the binaries are available as
-`<snapname.binaryname>` on the commandline. It can be tested by simply
-running it from the commandline. Common issues are that the application tries
-to read/write outside of its confinement. This will result in permission
-denied errors even if the app runs as root. To see if this is the case, the
-`dmesg | tail` command is helpful. The errors are of the form:
+After a snap is installed the binaries are available as `<snapname.binaryname>`
+on the commandline. It can be tested by simply running it from the commandline. Common issues are that the application tries to read/write outside of its confinement. This will result in permission denied errors even if the app runs
+as root. To see if this is the case, the `dmesg | tail` command is helpful. The
+errors are of the form:
 
-```
-[ 8020.798544] audit: type=1400 audit(1442568421.022:9): apparmor="DENIED" operation="open" profile="pastebinit.mvo_pastebinit_1.4.0.0.2" name="/etc/fstab" pid=1123 comm="pastebinit" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
-```
+    [ 8020.798544] audit: type=1400 audit(1442568421.022:9): apparmor="DENIED" operation="open" profile="pastebinit.mvo_pastebinit_1.4.0.0.2" name="/etc/fstab" pid=1123 comm="pastebinit" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
 
 To find out what paths are available to write the `hello-world` package is
 helpful. After installing it the command `hello-world.env` is available that
 will show the environment that the snap binaries see. The
 `SNAP_USER_DATA` and `SNAP_DATA` contain the directories that the application
 is allowed to write to.
-
-### Tracing a binary
-
-In order to trace what a binary is doing the usual tools like gdb and strace
-can be used. See the section above about debugging about for details how to
-get the debug snap.
 
 ## Testing a service
 
@@ -208,7 +99,7 @@ can write to (usually `SNAP_DATA`).
 To enable core dumps you have to configure a place to write them to through
 `sysfs`. For instance you can use
 
-    echo "/tmp/core.%e.%p" > /proc/sys/kernel/core_pattern
+    $ echo "/tmp/core.%e.%p" > /proc/sys/kernel/core_pattern
 
 to ensure that your coredumps get written into the `/tmp` directory
 regardless of where `CWD` of the process that received a signal was.
@@ -220,9 +111,6 @@ regardless of where `CWD` of the process that received a signal was.
 The Snappy system comes with several tools to assist with understanding and
 debugging security policy:
 
-* **snappy-debug.security list**: used for listing available policy
-* **snappy-debug.security scanlog**: used for scanning /var/log/syslog for
-  policy violations in an easier to read format
 * **snap list**: lists installed snaps
 * **sudo aa-status**: shows AppArmor policy that is loaded in the kernel
 
@@ -249,19 +137,12 @@ app include:
 * app doesn't start
 
 It is easy to see if the app is being blocked by security policy by looking
-at the logs (be sure to run `sudo snap install snappy-debug` first):
+at the syslog:
 
-```
-$ sudo snappy-debug.security scanlog
-= AppArmor =
-Time: Oct  1 15:21:53
-Log: apparmor="DENIED" operation="open" profile="hello-world.canonical_sh_1.0.18" name="/etc/ssh/ssh_host_rsa_key" pid=1060 comm="cat" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
-
-= Seccomp =
-Time: Oct  1 15:27:43
-Log: auid=1000 uid=0 gid=0 ses=6 pid=1101 comm="ls" exe="/bin/ls" sig=31 arch=c000003e 41(socket) compat=0 ip=0x7f37396140b7 code=0x0
-Syscall: socket
-```
+    $ sudo tail -f /var/log/syslog
+    audit(1461950701.631:49): apparmor="DENIED" operation="open" profile="hello-world.canonical_sh_1.0.18" name="/etc/ssh/ssh_host_rsa_key" pid=1060 comm="cat" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
+    <...>
+    audit(1461950702.321:54): auid=1000 uid=0 gid=0 ses=6 pid=1101 comm="ls" exe="/bin/ls" sig=31 arch=c000003e 41(socket) compat=0 ip=0x7f37396140b7 code=0x0
 
 Notice in the second line that a process running under the
 `hello-world.canonical_sh_1.0.18` AppArmor label
@@ -301,10 +182,10 @@ The most common culprits for sandbox issues are:
     * hard coded paths in the program. The program should be adjusted ideally
       to understand `SNAP_` variables or use relative paths
 * Attempting to read files outside of `SNAP`, `SNAP_DATA` and
-  `SNAP_USER`. This usually happens if your program is looking for something
-  that isn't shipped by your snap or it is trying to look for it in the wrong
-  place (eg, typing a `SNAP_` variable, evaluating `PATH` or hardcoded path).
-  Fixes are similar to the above
+  `SNAP_USER_DATA`. This usually happens if your program is looking for
+  something that isn't shipped by your snap or it is trying to look for it in
+  the wrong place (eg, typing a `SNAP_` variable, evaluating `PATH` or hardcoded
+  path). Fixes are similar to the above.
 * Attempting to use `/var/tmp`'. The program should be adjusted to use
   `TMPDIR` or `/tmp`
 * Attempting to use `/run`. The program should be adjusted to use
@@ -312,7 +193,7 @@ The most common culprits for sandbox issues are:
 * Access denied to hardware. Such access is granted via interfaces-- make sure
   you're using the correct one, and log a bug if an interface is missing
   something you need.
-* Not specifying the correct interfaces for your snap (eg, not using
+* Not specifying the correct interfaces for your snap (e.g., not using
   `network-bind` for server software)
 * Trying to execute programs on the system or programs in `/snap/bin`. Except
   for a few common programs (e.g., that are useful for shell programming),
@@ -382,18 +263,13 @@ app:
 When resolving sandbox issues, the first thing you should do is disable
 kernel rate limiting, otherwise the kernel may choose to not log important
 information needed for debugging (even with this, the kernel may still drop
-log messages (rarely)-- if you feel this is the case, reboot and try again):
+log messages (rarely)-- if you feel this is the case, reboot and try again).
+The rest of this section discusses how to debug sandbox issues for an installed
+snap.
 
-    $ sudo snap install snappy-debug
-    $ sudo snappy-debug.security disable-rate-limiting
-
-This rest of this section discusses how to debug sandbox issues for an
-installed snap.
-
-If you suspect sandbox issues when running your app, simply use the
-`snappy-debug.security scanlog` tool. If it doesn't report any issues, it is
-unlikely that security policy is to blame but other parts of the system may
-deny specific accesses. Eg:
+If you suspect sandbox issues when running your app, look for denials in
+syslog. If you don't see any, it's unlikely that security policy is to blame but
+other parts of the system may deny specific accesses. For example:
 * traditional UNIX permissions are in place. If you get a permission denied
   error with nothing in the logs, be sure to check the permissions on the
   file with `stat <file>`
@@ -413,218 +289,4 @@ deny specific accesses. Eg:
 Keep in mind that the cgroup will only exist while the program is running, so
 short-running `binaries` won't have the above cgroups entry (for debugging
 cgroups, it might be helpful for the binary to drop to a shell or run a sleep
-command)
-
-It is very convenient for debugging to login to your device and launch
-`snappy-debug.security scanlog`. Then in another console login, use your
-snap. For example, in one console:
-
-```
-$ sudo snap install snappy-debug
-$ sudo snappy-debug.security scanlog
-```
-
-Now, login to another console and try to start a service:
-
-```
-$ sudo snap service start xkcd-webserver
-$ sudo systemctl status snap.xkcd-webserver.xkcd-webserver
-Snap        Service        State
-xkcd-webserver    xkcd-webserver    enabled; loaded; failed (failed)
-```
-
-We can see that the service failed to start. Let's look back at the console
-running `snappy-debug.security scanlog`:
-
-```
-= Seccomp =
-Time: Oct  1 17:03:30
-Log: auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2409 comm="xkcd-webserver" exe="/usr/bin/python3.4" sig=31 arch=c000003e 54(setsockopt) compat=0 ip=0x7f4aebf0d05a code=0x0
-Syscall: setsockopt
-Recommendation:
-* add 'setsockopt' to seccomp policy
-* add one of 'network-client, network-firewall, network-service' to 'caps'
-* add 'setsockopt' to seccomp file in 'security-policy'
-```
-
-Ah, `xkcd-webserver` is a web server and we apparently forgot to include the
-`network-bind` in our 'plugs' in the yaml. At this point, you could simply
-add it to the `plugs` for that service, rebuild the snap, remove the old snap
-and install the new one. Eg, after adding the `network-bind` interface:
-
-```
-$ sudo systemctl start snap.xkcd-webserver.xkcd-webserver
-$ sudo systemctl status snap.xkcd-webserver.xkcd-webserver
-Snap        Service        State
-xkcd-webserver    xkcd-webserver    enabled; loaded; active (running)
-```
-
-For simple things like forgetting an interface, rebuilding and reinstalling the
-snap is enough. Other times you might be developing custom policy for a
-specialized snap or want to simply allow some accesses temporarily. In these
-cases it is usually easier to modify policy in place on the device to get
-everything working (and if working on custom policy, copying this back to your
-packaging files).
-
-IMPORTANT: whether you are using templated policy, `security-override` or
-`security-policy`, the actual security policy that is applied at runtime is
-autogenerated during snappy install based on the snap's packaging. On Ubuntu
-Core 15.04, the autogenerated policy for AppArmor is found in
-`/var/lib/apparmor/profiles` and the autogenerated policy for seccomp is in
-`/var/lib/snappy/seccomp/profiles`.
-
-Now let's walk through a couple of real world examples. Consider this in the
-snappy packaging:
-
-```yaml
-name: foo
-version: 1.0
-vendor: Some One <some.one@example.com>
-icon: meta/hello.png
-binaries:
- - name: bin/bar
-   caps: []
-```
-
-Now consider this output:
-
-```
-$ sudo snappy-debug.security scanlog
-= AppArmor =
-Time: Oct  2 03:20:49
-Log: apparmor="DENIED" operation="mknod" profile="foo.sideload_bar_ICKPCGbSJVMW" name="/snaps/foo.sideload/ICKPCGbSJVMW/stamp-file" pid=2545 comm="touch" requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000
-File: /snaps/foo.sideload/ICKPCGbSJVMW/stamp-file (write)
-Suggestion:
-* adjust program to not write to SNAP
-```
-
-`snappy-debug.security scanlog`' conveniently is suggesting that the app is
-trying to write to the install directory (`SNAP`). Looking at
-`/snaps/foo.sideload/ICKPCGbSJVMW/bin/bar`, there is:
-
-```sh
-#!/bin/bash -e
-touch ./stamp-file
-```
-
-Quickly adjust that to be:
-
-```sh
-#!/bin/bash -e
-touch $SNAP_DATA/stamp-file
-```
-
-then run the app again. The logs don't show the stamp-file denial (so now
-would be a good time to apply this change to `bin/bar` on your development
-machine), but do show a new denial:
-
-```
-= AppArmor =
-Time: Oct  2 03:30:35
-Log: apparmor="DENIED" operation="open" profile="foo.sideload_bar_ICKPCGbSJVMW" name="/etc/motd" pid=2582 comm="cat" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
-File: /etc/motd (read)
-Suggestions:
-* adjust program to read necessary files from SNAP
-* add '/etc/motd r,' to apparmor in 'security-policy'
-```
-
-Let's temporarily add the suggested rule to
-`/var/lib/apparmor/profiles/*_foo.sideload_bar_*` (before the trailing `}`):
-
-```
-...
-profile "foo.sideload_bar_ICKPCGbSJVMW" (attach_disconnected) {
-  #include <abstractions/base>
-  ...
-  /etc/motd r
-}
-```
-
-Now, reload the policy:
-
-```
-$ sudo snappy-debug.security reload foo.sideload
-Reloading foo.sideload_bar_ICKPCGbSJVMW ...
-AppArmor parser error for ...
-```
-
-Whoops, we forgot the trailing comma in the AppArmor rule. Adjust it to be:
-
-```
-  ...
-  /etc/motd r,
-}
-```
-
-Now, reload the policy again:
-
-```
-$ sudo snappy-debug.security reload foo.sideload
-Reloading foo.sideload_bar_ICKPCGbSJVMW ...
-```
-
-Now, rerun the app and look at the logs:
-
-```
-= Seccomp =
-Time: Oct  2 03:48:45
-Log: auid=1000 uid=0 gid=0 ses=32 pid=2787 comm="xtables-multi" exe="/var/lib/apps/foo.sideload/ICKPCGbSJVMW/xtables-multi" sig=31 arch=c000003e 49(bind) compat=0 ip=0x7fcf76dbfc07 code=0x0
-Syscall: bind
-Suggestions:
-* add 'bind' to seccomp policy
-* add one of 'hello-dbus-fwk_client, network-admin, network-client, network-firewall, network-service, network-status, snapd' to 'caps'
-* add 'bind' to seccomp file in 'security-policy'
-```
-
-Let's temporarily add this sycall to
-`/var/lib/snappy/seccomp/profiles/foo.sideload_bar_*`:
-
-```
-...
-pwrite
-pwrite64
-pwritev
-# temporary
-bind
-```
-
-Modifying the seccomp policy in this manner does not require a separate
-reload step (because the launcher will handle this for us). Rerun the app
-again and check the logs:
-
-```
-= AppArmor =
-Time: Oct  2 03:56:24
-Log: apparmor="DENIED" operation="bind" profile="foo.sideload_bar_ICKPCGbSJVMW" pid=2826 comm="xtables-multi" family="unix" sock_type="stream" protocol=0 requested_mask="bind" denied_mask="bind" addr="@xtables"
-Suggestion:
-* add 'unix addr="@xtables",' to apparmor in 'security-policy'
-* add one of 'network-firewall' to 'caps'
-```
-
-Now temporarily add a unix rule to
-`/var/lib/apparmor/profiles/*_foo.sideload_bar_*`:
-
-    unix addr="@xtables",
-
-As can be seen from the above example, adding temporary policy or developing
-custom policy is an iterative process and can take some effort, but the steps
-are not complicated:
-
-* run the app
-* check the logs
-* add any necessary rules
-* repeat
-
-Once there are no denials on app start, exercise the app fully and continue
-watching the logs for new denials, updating and reloading the policy until
-you have all the temporary accesses you need. These temporary accesses might
-be sufficient while developing your snap until you are able to remove the
-need for these accesses (while these changes will survive a reboot, they will
-be lost on app reinstall or upgrades). If you require the additional rules,
-use `security-policy` in your yaml and follow the guidelines in
-'Developing customized security policy', above, start with boilerplate policy
-and copy these new rules in, and retest. Remember that store policies may
-trigger a manual review for uploads of snaps specifying `security-policy`.
-Notice in many of the above logs, the recommendation was to use various
-interfaces. It is recommended that templated policy with interfaces be used
-whenever possible rather than generating your own custom policy.
+command).

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -148,10 +148,9 @@ in `shout.sergiusens` run: `sudo snappy service logs shout`).
 
 ### Installing binaries
 In order to test a new snap on a Snappy system you need to install it first.
-This is called sideloading and it can be done via
-`snappy-remote --url=ssh://ubuntu@webdm.local/ install snapname.snap`.
-Alternatively the snap can be copied via scp into the Snappy system and
-installed via `sudo snappy install snapname.snap`.
+This is called "sideloading" and it can be done by copying the snap onto the
+Snappy system via `scp` and installing it with
+`sudo snappy install snapname.snap`.
 
 Note that you have to use the `--allow-unauthenticated` tag for installing
 unsigned snaps: `sudo snappy install --allow-unauthenticated snapname.snap`.

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -80,14 +80,14 @@ for the various ways to do that. Once it is installed systemd's `systemctl`
 command can be used to see if the service starts and runs as expected, for
 example:
 
-    systemctl status snap.<name>.<service>
+    systemctl status snap.<name>.<appname>
 
 ### Finding the logs
 
 The `journalctl` command can be used to inspect the messages that the service
 sends to `stdout`/`stderr`, for example:
 
-    journalctl -u snap.<name>.<service>
+    journalctl -u snap.<name>.<appname>
 
 Services may log additional data to syslog (`/var/log/syslog`) or to custom log
 directories. Note that custom log directories must be in a path that the service

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -2,7 +2,7 @@
 
 Ubuntu is an excellent OS for developers. The Snappy developer tools are
 readily available in Ubuntu, so porting and writing new software to target a
-Snappy-based system is particularly easy.
+Snap-based system is particularly easy.
 
 For app developers that want the latest stable tools to work on Snappy
 technology, we recommend using the latest classic Ubuntu Long-Term Support

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,33 +1,25 @@
 # Getting set up
 
-Ubuntu is a great and convenient OS for developers. Snappy developer tools are
-readily available to enable app developers familiar with Ubuntu to port and
-write new software for a snappy-based system easily.
+Ubuntu is an excellent OS for developers. The Snappy developer tools are
+readily available in Ubuntu, so porting and writing new software to target a
+Snappy-based system is particularly easy.
 
 For app developers that want the latest stable tools to work on Snappy
-technology, we recommend to use the latest classic Ubuntu Long-Term Support
-(LTS) release as the host. At the time of writing this is Ubuntu 14.04 LTS. For
-those not using an Ubuntu machine (and you should), you can use a VM
-(VirtualBox, VMware, Vagrant) to execute your Ubuntu development host.
+technology, we recommend using the latest classic Ubuntu Long-Term Support
+(LTS) release as the host. At the time of writing this is Ubuntu 16.04 LTS. For
+those not using an Ubuntu machine, you can use a virtual machine (e.g.
+VirtualBox, VMware, Vagrant, etc.) to run your Ubuntu development environment.
 
-This version of snapcraft only works on Ubuntu 16.04 (Xenial Xerus), for
-previous versions of snapcraft, refer to the
-[1.x documentation](https://github.com/ubuntu-core/snapcraft/blob/1.x/docs/get-started.md).
+**Note:** If you're targeting Snappy 15.04, you should be using
+[Snapcraft 1][1], which is only supported on releases prior to 16.04.
 
-Once your Ubuntu host system is up and running, you can then install the
-`snappy-tools` package, which will in turn install the optimal selection of
-Snappy development software to your system.
+Once your Ubuntu system is up and running, simply install Snapcraft:
 
-	$ sudo apt install snappy-tools
+    $ sudo apt install snapcraft
 
-For a production environment, we recommend using an Ubuntu LTS-based host.
-
-This is the most important selection of tools you will get after installation:
-
-	snappy try          - try snaps from a .snap, the [stage] or [snap] dir
-	snappy-remote 	    - run snappy operations on remote snappy target by IP
-	snapcraft           - the snap build tool for all snaps
 
 # Next
 
 How about putting together [your first snap](your-first-snap.md) now?
+
+[1]: https://github.com/ubuntu-core/snapcraft/blob/1.x/docs/get-started.md

--- a/docs/mir-snaps.md
+++ b/docs/mir-snaps.md
@@ -76,8 +76,8 @@ user is "ubuntu" and password is "ubuntu". Check your ip with ipconfig.
 
 Copy your snap over to your running core image & install.
 ```
-$ scp *.snap ubuntu@x.x.x.x:/home/ubuntu
-ubuntu# sudo snappy install mir*.snap --allow-unauthenticated
+$ scp *.snap ubuntu@x.x.x.x:
+ubuntu# sudo snap install mir*.snap
 ```
 
 The `mir-server` should launch, resulting in a black screen with a mouse.
@@ -86,12 +86,12 @@ The `mir-server` should launch, resulting in a black screen with a mouse.
 
 You may stop the `mir-server` if you want or have need by `Ctl+delete` or
 ```
-ubuntu# sudo snappy service stop mir
+ubuntu# sudo snap service stop mir
 ```
 
 Likewise, you may restart by
 ```
-ubuntu# sudo snappy service start mir
+ubuntu# sudo snap service start mir
 ```
 
 ## Get the Mir-Client snap Running
@@ -108,12 +108,12 @@ $ snapcraft snap
 
 Copy your snap over to your running core image and install.
 ```
-$ scp *.snap ubuntu@x.x.x.x:/home/ubuntu
+$ scp *.snap ubuntu@x.x.x.x:
 ```
 
 Quickly double-check Mir server is running, if not just start the service.
 ```
-ubuntu# sudo snappy install mir-client*.snap --allow-unauthenticated
+ubuntu# sudo snap install mir-client*.snap
 ```
 
 At this point you should see some Qml clocks.

--- a/docs/ros-snap.md
+++ b/docs/ros-snap.md
@@ -349,15 +349,13 @@ you'll have a .snap.
 
 ### Take the .snap for a test drive
 
-You can transfer your newly-minted .snap to your Ubuntu Core machine and install
-it at the same time via `snappy-remote`, for example:
+Transfer your newly-minted .snap to your Ubuntu Core machine with `scp`,
+then install it:
 
-    $ snappy-remote --url=ssh://<host>:<port> install \
-      ros-example_1.0_amd64.snap
+    $ sudo snappy install ros-example_1.0_amd64.snap
 
-Now on the Ubuntu Core machine, take a look in `/snaps/bin/`, and you'll see the
-binary you requested, called `ros-example.launch-project`. Test it
-out:
+While on the Ubuntu Core machine, take a look in `/snaps/bin/`, and you'll see
+the binary you requested, called `ros-example.launch-project`. Test it out:
 
     $ ros-example.launch-project
 

--- a/docs/ros-snap.md
+++ b/docs/ros-snap.md
@@ -349,22 +349,21 @@ you'll have a .snap.
 
 ### Take the .snap for a test drive
 
-Transfer your newly-minted .snap to your Ubuntu Core machine with `scp`,
-then install it:
+Install your newly-minted .snap with:
 
-    $ sudo snappy install ros-example_1.0_amd64.snap
+    $ sudo snap install ros-example_1.0_amd64.snap
 
-While on the Ubuntu Core machine, take a look in `/snaps/bin/`, and you'll see
-the binary you requested, called `ros-example.launch-project`. Test it out:
+Take a look in `/snap/bin/`, and you'll see the binary you requested, called
+`ros-example.launch-project`. Test it out:
 
     $ ros-example.launch-project
 
 And you should see the talker and listener communicating like before. As usual,
 ctrl+c will stop it. Note also that, since ROS is running in a confined
 environment, its log isn't in `$HOME/.ros` as usual, but in
-`$HOME/snaps/ros-example.sideload/<version>/ros`. Note: if you make the app a
+`$HOME/snap/ros-example.sideload/<version>/ros`. Note: if you make the app a
 service, `$HOME` will be `/root`, so the logs will be in
-`/root/snaps/ros-example.sideload/<version>/ros`.
+`/root/snap/ros-example.sideload/<version>/ros`.
 
 [1]: http://www.ros.org/
 [2]: get-started.md

--- a/docs/snapcraft-usage.md
+++ b/docs/snapcraft-usage.md
@@ -19,15 +19,9 @@ inside the parts entry.
 
 ## Sideloading your snap
 
-Consider the `downloader-with-wiki-parts` example and a Snappy Ubuntu Core
-on 192.168.10.10. In order to install the built snap, you need to first get the
-snap on the device and then install it. From the host machine:
+Consider the `downloader-with-wiki-parts` example. To install the built snap:
 
-    $ scp downloader_1.0_amd64.snap ubuntu@192.168.10.10:
-
-Now from the home directory of the ubuntu user on the Snappy machine:
-
-	$ sudo snappy install downloader_1.0_amd64.snap --allow-unauthenticated
+	$ sudo snap install downloader_1.0_amd64.snap
 
 After installing, a summary of installed snaps will be presented, on a vanilla
 x86-64 bit system it would look a lot like this:

--- a/docs/snapcraft-usage.md
+++ b/docs/snapcraft-usage.md
@@ -20,16 +20,16 @@ inside the parts entry.
 ## Sideloading your snap
 
 Consider the `downloader-with-wiki-parts` example and a Snappy Ubuntu Core
-on 192.168.10.10, to install the built snap by following Trying snapcraft
-and run:
+on 192.168.10.10. In order to install the built snap, you need to first get the
+snap on the device and then install it. From the host machine:
 
-	snappy-remote --url ssh://192.168.10.10 install downloader_1.0_amd64.snap
+    $ scp downloader_1.0_amd64.snap ubuntu@192.168.10.10:
 
-If this is the first time connecting to the system, snappy-remote will try
-and use existing ssh keys for the user to avoid the necessity of password
-prompts.
+Now from the home directory of the ubuntu user on the Snappy machine:
 
-After installing a summary of installed snaps will be presented, on vanilla
+	$ sudo snappy install downloader_1.0_amd64.snap --allow-unauthenticated
+
+After installing, a summary of installed snaps will be presented, on a vanilla
 x86-64 bit system it would look a lot like this:
 
 	Name          Date       Version      Developer


### PR DESCRIPTION
Remove any mention of snappy-remote, snappy-tools, snappy-debug, and other old Snappy things. This fixes LP: [#1568113](https://bugs.launchpad.net/snapcraft/+bug/1568113).