### PR TITLE
Nil plugin: Make purpose more clear in documentation.

### DIFF
--- a/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
+++ b/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
@@ -1,0 +1,9 @@
+name: test-package
+version: 0.1
+summary: Use source with nil
+description: Use source with nil (which should error out)
+
+parts:
+    nil-part:
+        plugin: nil
+        source: '.'

--- a/integration_tests/test_nil_plugin.py
+++ b/integration_tests/test_nil_plugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import subprocess
 
 import integration_tests
 
@@ -27,3 +28,14 @@ class NilPluginTestCase(integration_tests.TestCase):
 
         dirs = os.listdir(os.path.join(project_dir, 'snap'))
         self.assertEqual(['meta'], dirs)
+
+    def test_nil_no_additional_properties(self):
+        project_dir = 'nil-with-additional-properties'
+
+        exception = self.assertRaises(
+            subprocess.CalledProcessError, self.run_snapcraft, 'snap',
+            project_dir)
+
+        self.assertTrue(
+            "Additional properties are not allowed ('source' was unexpected)"
+            in exception.output.replace('\n', ' ').strip())

--- a/snapcraft/plugins/nil.py
+++ b/snapcraft/plugins/nil.py
@@ -14,11 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The nil plugin is useful for parts with entirely built in properties.
+"""The nil plugin is useful for parts with no source.
 
-The nil plugin allows parts that do nothing. As a result parts can be defined
-that, for example, have no source, but can still make use of all the properties
-available in snapcraft.
+Using this, parts can be defined purely by utilizing properties automatically
+included by Snapcraft, e.g. stage-packages.
 """
 
 import snapcraft
@@ -31,6 +30,7 @@ class NilPlugin(snapcraft.BasePlugin):
         return {
             '$schema': 'http://json-schema.org/draft-04/schema#',
             'type': 'object',
+            'additionalProperties': False,
             'properties': {},
         }
 

--- a/snapcraft/tests/test_commands_build.py
+++ b/snapcraft/tests/test_commands_build.py
@@ -35,8 +35,7 @@ parts:
 {parts}"""
 
     yaml_part = """  build{:d}:
-    plugin: nil
-    source: ."""
+    plugin: nil"""
 
     def make_snapcraft_yaml(self, n=1):
         parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -39,8 +39,7 @@ parts:
 {parts}"""
 
     yaml_part = """  clean{:d}:
-    plugin: nil
-    source: ."""
+    plugin: nil"""
 
     def make_snapcraft_yaml(self, n=1, create=True):
         parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])
@@ -180,16 +179,13 @@ description: test clean
 parts:
   main:
     plugin: nil
-    source: .
 
   dependent:
     plugin: nil
-    source: .
     after: [main]
 
   nested-dependent:
     plugin: nil
-    source: .
     after: [dependent]""")
 
         self.part_dirs = {}

--- a/snapcraft/tests/test_commands_stage.py
+++ b/snapcraft/tests/test_commands_stage.py
@@ -35,8 +35,7 @@ parts:
 {parts}"""
 
     yaml_part = """  stage{:d}:
-    plugin: nil
-    source: ."""
+    plugin: nil"""
 
     def make_snapcraft_yaml(self, n=1):
         parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])

--- a/snapcraft/tests/test_commands_strip.py
+++ b/snapcraft/tests/test_commands_strip.py
@@ -35,8 +35,7 @@ parts:
 {parts}"""
 
     yaml_part = """  strip{:d}:
-    plugin: nil
-    source: ."""
+    plugin: nil"""
 
     def make_snapcraft_yaml(self, n=1):
         parts = '\n'.join([self.yaml_part.format(i) for i in range(n)])

--- a/snapcraft/tests/test_plugin_nil.py
+++ b/snapcraft/tests/test_plugin_nil.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2015 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from snapcraft.plugins.nil import NilPlugin
+from snapcraft.tests import TestCase
+
+
+class TestNilPlugin(TestCase):
+    def test_schema(self):
+        schema = NilPlugin.schema()
+        self.assertEqual('http://json-schema.org/draft-04/schema#',
+                         schema['$schema'])
+        self.assertEqual('object', schema['type'])
+        self.assertFalse(schema['additionalProperties'])
+        self.assertFalse(schema['properties'])

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -1345,7 +1345,7 @@ class CleanTestCase(tests.TestCase):
             with self.subTest(key=key):
                 self.clear_common_directories()
 
-                schema = {'snap': {'type': 'array'}}
+                schema = {'stage': {'type': 'array'}}
                 properties = {'stage': value['fileset']}
 
                 handler = pluginhandler.load_plugin(


### PR DESCRIPTION
Some users were under the impression that nil could pull sources, when it can't. This PR resolves LP: [#1549691](https://bugs.launchpad.net/snapcraft/+bug/1549691) by hopefully making that more clear, and giving an example of what it CAN do.