### PR TITLE
Remove LXD container once we've finished a build

### DIFF
--- a/snapcraft/lxd.py
+++ b/snapcraft/lxd.py
@@ -35,11 +35,11 @@ _PROXY_KEYS = ['http_proxy', 'https_proxy', 'no_proxy', 'ftp_proxy']
 
 class Cleanbuilder:
 
-    def __init__(self, snap_output, project, deb_arch,
+    def __init__(self, snap_output, tar_filename, project_options,
                  server=_DEFAULT_IMAGE_SERVER):
         self._snap_output = snap_output
-        self._project = project
-        self._deb_arch = deb_arch
+        self._tar_filename = tar_filename
+        self._project_options = project_options
         self._container_name = 'snapcraft-{}'.format(
             petname.Generate(3, '-'))
         self._server = server
@@ -62,7 +62,8 @@ class Cleanbuilder:
             check_call(['lxc', 'remote', 'add', remote_tmp, self._server])
             check_call([
                 'lxc', 'launch',
-                '{}:ubuntu/xenial/{}'.format(remote_tmp, self._deb_arch),
+                '{}:ubuntu/xenial/{}'.format(
+                    remote_tmp, self._project_options.deb_arch),
                 self._container_name])
             yield
         finally:
@@ -81,8 +82,8 @@ class Cleanbuilder:
 
     def _setup_project(self):
         logger.info('Setting up container with project assets')
-        dst = os.path.join('/root', os.path.basename(self._project))
-        self._push_file(self._project, dst)
+        dst = os.path.join('/root', os.path.basename(self._tar_filename))
+        self._push_file(self._tar_filename, dst)
         self._container_run(['tar', 'xvf', dst])
 
     def _pull_snap(self):

--- a/snapcraft/lxd.py
+++ b/snapcraft/lxd.py
@@ -68,6 +68,7 @@ class Cleanbuilder:
             yield
         finally:
             check_call(['lxc', 'stop', self._container_name])
+            check_call(['lxc', 'delete', self._container_name])
             check_call(['lxc', 'remote', 'remove', remote_tmp])
 
     def execute(self):

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -28,6 +28,8 @@ from snapcraft import (
     tests,
 )
 
+from snapcraft._options import ProjectOptions  # noqa
+
 
 class LXDTestCase(tests.TestCase):
 
@@ -38,7 +40,9 @@ class LXDTestCase(tests.TestCase):
         self.useFixture(fake_logger)
 
         mock_pet.return_value = 'my-pet'
-        lxd.Cleanbuilder('snap.snap', 'project.tar', 'amd64').execute()
+
+        project_options = ProjectOptions()
+        lxd.Cleanbuilder('snap.snap', 'project.tar', project_options).execute()
 
         self.assertEqual(
             'Setting up container with project assets\n'

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -76,6 +76,7 @@ class LXDTestCase(tests.TestCase):
                   'snapcraft-my-pet//root/snap.snap',
                   'snap.snap']),
             call(['lxc', 'stop', 'snapcraft-my-pet']),
+            call(['lxc', 'delete', 'snapcraft-my-pet']),
             call(['lxc', 'remote', 'remove', 'my-pet'])])
 
     @patch('snapcraft.lxd.check_call')


### PR DESCRIPTION
There is no need to keep a container if we take a different name
each time we run a build anyway. Container construction is fast
and therefor we can just drop the container once we're done with it.
    
LP: #1570708