### PR TITLE
add SNAP_LIBRARY_PATH

### DIFF
--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -193,6 +193,7 @@ class _SnapPackaging:
         script = ('#!/bin/sh\n' +
                   '{}\n'.format(assembled_env) +
                   '{}\n'.format(cwd) +
+                  'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
                   'exec {} {}\n'.format(executable, args))
 
         with open(wrappath, 'w+') as f:


### PR DESCRIPTION
Trivial branch that adds the new SNAP_LIBRARY_PATH so that the right paths for opengl will be used.