### PR TITLE
Kernel plugin: Support lzma/xz-compressed initrd.

### DIFF
--- a/examples/96boards-kernel/snapcraft.yaml
+++ b/examples/96boards-kernel/snapcraft.yaml
@@ -24,6 +24,7 @@ parts:
     kernel-device-trees:
       - qcom/apq8016-sbc
       - qcom/msm8916-mtp
+    build-packages: [bc, kmod, cpio]
   410c-firmware:
     plugin: tar-content
     source: firmware.tar # from developer.qualcomm.com v1.2

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -57,6 +57,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 
 from snapcraft import storeapi
@@ -183,7 +184,8 @@ class KernelPlugin(kbuild.KBuildPlugin):
             tmp_initrd_path = os.path.join(
                 temp_dir, 'squashfs-root', initrd_path)
             cmd = shlex.split('file -L --mime-type {}'.format(tmp_initrd_path))
-            result = subprocess.check_output(cmd).decode('utf-8')
+            result = subprocess.check_output(cmd).decode(
+                sys.getfilesystemencoding())
             mime_type = result.split()[-1]
             logger.debug('initrd mime_type: {} {}'.format(
                 tmp_initrd_path, mime_type))

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -194,11 +194,12 @@ class KernelPlugin(kbuild.KBuildPlugin):
             logger.debug('initrd mime_type: {} {}'.format(
                 tmp_initrd_path, mime_type))
 
-            # Support gzip (can be gzip or x-gzip)
-            if 'gzip' in mime_type:
+            # Support gzip and lzma/xz
+            gzip_mime_types = ('application/gzip', 'application/x-gzip')
+            xz_mime_types = ('application/x-xz', 'application/x-lzma')
+            if any(x in mime_type for x in gzip_mime_types):
                 decompressor = 'gzip'
-            # Support lzma/xz
-            elif any(x in mime_type for x in ('x-xz', 'x-lzma')):
+            elif any(x in mime_type for x in xz_mime_types):
                 decompressor = 'xz'
             else:
                 raise RuntimeError(

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -186,7 +186,9 @@ class KernelPlugin(kbuild.KBuildPlugin):
             mime_detector = magic.open(
                 magic.MAGIC_MIME_TYPE | magic.MAGIC_ERROR)
             mime_detector.load()
-            mime_type = mime_detector.file(tmp_initrd_path)
+            # Make sure we're getting the mime type of the actual initrd, not
+            # a symbolic link.
+            mime_type = mime_detector.file(os.path.realpath(tmp_initrd_path))
             if not mime_type:
                 raise RuntimeError(
                     'Unable to determine mime type for {!r}: {}'.format(

--- a/snapcraft/plugins/kernel.py
+++ b/snapcraft/plugins/kernel.py
@@ -180,21 +180,22 @@ class KernelPlugin(kbuild.KBuildPlugin):
                 'unsquashfs', self.os_snap, os.path.dirname(initrd_path)],
                 cwd=temp_dir)
 
-            tmp_initrd_path = os.path.join(temp_dir, 'squashfs-root', initrd_path)
+            tmp_initrd_path = os.path.join(
+                temp_dir, 'squashfs-root', initrd_path)
             cmd = shlex.split('file -L --mime-type {}'.format(tmp_initrd_path))
-            result = subprocess.check_output(cmd)
-            mime_type = str(result.split()[-1])
-            logger.info('initrd mime_type: {} {}'.format(tmp_initrd_path, mime_type))
+            result = subprocess.check_output(cmd).decode('utf-8')
+            mime_type = result.split()[-1]
+            logger.debug('initrd mime_type: {} {}'.format(
+                tmp_initrd_path, mime_type))
             decompressor = 'gzip'
-            if "gzip" in mime_type:
+            if 'gzip' in mime_type:
                 decompressor = 'gzip'
-            elif "x-xz" in mime_type:
-                decompressor = 'xz'
-            elif "x-lzma" in mime_type:
+            elif any(x in mime_type for x in ('x-xz', 'x-lzma')):
                 decompressor = 'xz'
 
             subprocess.check_call(
-                'cat {0} | {1} -dc | cpio -i'.format(tmp_initrd_path, decompressor),
+                'cat {0} | {1} -dc | cpio -i'.format(
+                    tmp_initrd_path, decompressor),
                 shell=True, cwd=initrd_unpacked_path)
 
         return initrd_unpacked_path


### PR DESCRIPTION
This is another attempt at fixing LP: [#1569337](https://bugs.launchpad.net/snapcraft/+bug/1569337) which uses the magic library instead of shelling out to `file`. It also adds some tests.