### PR TITLE
Changed primitive apt-get to modern apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - TEST_SUITE=static
   - TEST_SUITE=unit
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y python3-coverage python3-distutils-extra
+  - sudo apt -qq update
+  - sudo apt install -y python3-coverage python3-distutils-extra
 install:
   - pip install docopt fixtures flake8 jsonschema lxml mccabe petname pexpect python-apt pyxdg pyyaml py3-progressbar requests requests-oauthlib requests-toolbelt responses setuptools ssoclient testscenarios file-magic
 script:

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,7 +10,7 @@ To see all the commands and options, run `snapcraft --help`.
 
 - You'll need to add the following dependencies to run the tests.
 
-    sudo apt-get install python3-flake8 python3-fixtures python3-testscenarios python3-mock python3-responses
+    sudo apt install python3-flake8 python3-fixtures python3-testscenarios python3-mock python3-responses
 
 Simply run the top level testing script:
 
@@ -18,7 +18,7 @@ Simply run the top level testing script:
 
 - If you want to get a test coverage report, install python3-coverage before running the tests:
 
-    sudo apt-get install python3-coverage
+    sudo apt install python3-coverage
 
 
 - If you don't want to run the plainbox integration tests, you can skip them by setting SNAPCRAFT_TESTS_SKIP_PLAINBOX=1 in your environment.

--- a/docs/mir-snaps.md
+++ b/docs/mir-snaps.md
@@ -37,7 +37,7 @@ in a clean environment. Also, make sure Virtual Machine Manager is installed,
 from Ubuntu Software Center or
 
 ```
-apt-get install virt-manager
+apt install virt-manager
 ```
 
 ### Get the Mir Snap running first

--- a/snapcraft/lxd.py
+++ b/snapcraft/lxd.py
@@ -74,8 +74,8 @@ class Cleanbuilder:
         with self._create_container():
             self._setup_project()
             self._wait_for_network()
-            self._container_run(['apt-get', 'update'])
-            self._container_run(['apt-get', 'install', 'snapcraft', '-y'])
+            self._container_run(['apt', 'update'])
+            self._container_run(['apt', 'install', 'snapcraft', '-y'])
             self._container_run(
                 ['snapcraft', 'snap', '--output', self._snap_output])
             self._pull_snap()

--- a/snapcraft/repo.py
+++ b/snapcraft/repo.py
@@ -86,7 +86,7 @@ def install_build_packages(packages):
             'DEBIAN_FRONTEND': 'noninteractive',
             'DEBCONF_NONINTERACTIVE_SEEN': 'true',
         })
-        subprocess.check_call(['sudo', 'apt-get', '-o',
+        subprocess.check_call(['sudo', 'apt', '-o',
                                'Dpkg::Progress-Fancy=1',
                                '--no-install-recommends', '-y',
                                'install'] + new_packages, env=env)

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -67,9 +67,9 @@ class LXDTestCase(tests.TestCase):
                   '"http://start.ubuntu.com/connectivity-check.html", '
                   'timeout=5)']),
             call(['lxc', 'exec', 'snapcraft-my-pet', '--',
-                  'apt-get', 'update']),
+                  'apt', 'update']),
             call(['lxc', 'exec', 'snapcraft-my-pet', '--',
-                  'apt-get', 'install', 'snapcraft', '-y']),
+                  'apt', 'install', 'snapcraft', '-y']),
             call(['lxc', 'exec', 'snapcraft-my-pet', '--',
                   'snapcraft', 'snap', '--output', 'snap.snap']),
             call(['lxc', 'file', 'pull',


### PR DESCRIPTION
This will change the apt-get command to apt, which is recommended by the apt team and has more features and flexibility. I ran:

```
$ grep -r "apt-get"
snapcraft/tests/test_lxd.py:                  'apt-get', 'update']),
snapcraft/tests/test_lxd.py:                  'apt-get', 'install', 'snapcraft', '-y']),
snapcraft/repo.py:        subprocess.check_call(['sudo', 'apt-get', '-o',
snapcraft/lxd.py:            self._container_run(['apt-get', 'update'])
snapcraft/lxd.py:            self._container_run(['apt-get', 'install', 'snapcraft', '-y'])
docs/mir-snaps.md:apt-get install virt-manager
.travis.yml:  - sudo apt-get -qq update
.travis.yml:  - sudo apt-get install -y python3-coverage python3-distutils-extra
HACKING.md:    sudo apt-get install python3-flake8 python3-fixtures python3-testscenarios python3-mock python3-responses
HACKING.md:    sudo apt-get install python3-coverage
```

And it seems this is a good thing to do. So I ran:

`$ find . -type f -print0 | xargs -0 sed -i 's/apt-get/apt/g'`

And then I confirmed it worked well by grepping again.

From `man apt`:

```
SCRIPT USAGE AND DIFFERENCES FROM OTHER APT TOOLS
       The apt(8) commandline is designed as an end-user tool and it may change behavior between versions. While it tries not to break backward
       compatibility this is not guaranteed either if a change seems beneficial for interactive use.

       All features of apt(8) are available in dedicated APT tools like apt-get(8) and apt-cache(8) as well.  apt(8) just changes the default value of
       some options (see apt.conf(5) and specifically the Binary scope). So you should prefer using these commands (potentially with some additional
       options enabled) in your scripts as they keep backward compatibility as much as possible.
```

I believe this will be a lot better than using apt-get in snapcraft.