### PR TITLE
Fix shell quoting

### DIFF
--- a/integration_tests/snaps/assemble/binary1.after
+++ b/integration_tests/snaps/assemble/binary1.after
@@ -2,4 +2,4 @@
 export PATH="$SNAP/bin:$SNAP/usr/bin:$PATH"
 
 LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
-exec "$SNAP/binary1" $*
+exec "$SNAP/binary1" "$@"

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -50,7 +50,7 @@ def run(cmd, **kwargs):
     with tempfile.NamedTemporaryFile(mode='w+') as f:
         f.write(assemble_env())
         f.write('\n')
-        f.write('exec $*')
+        f.write('exec "$@"')
         f.flush()
         subprocess.check_call(['/bin/sh', f.name] + cmd, **kwargs)
 
@@ -61,7 +61,7 @@ def run_output(cmd, **kwargs):
     with tempfile.NamedTemporaryFile(mode='w+') as f:
         f.write(assemble_env())
         f.write('\n')
-        f.write('exec $*')
+        f.write('exec "$@"')
         f.flush()
         output = subprocess.check_output(['/bin/sh', f.name] + cmd, **kwargs)
         try:

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -174,7 +174,7 @@ class _SnapPackaging:
 
     def _write_wrap_exe(self, wrapexec, wrappath,
                         shebang=None, args=None, cwd=None):
-        args = ' '.join(args) + ' $*' if args else '$*'
+        args = ' '.join(args) + ' "$@"' if args else '"$@"'
         cwd = 'cd {}'.format(cwd) if cwd else ''
 
         assembled_env = common.assemble_env().replace(self._snap_dir, '$SNAP')

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -297,7 +297,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
                     'PATH=$SNAP/usr/bin:$SNAP/bin\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" $*\n')
+                    'exec "$SNAP/test_relexepath" "$@"\n')
 
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
@@ -323,7 +323,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
                     'PATH=$SNAP/usr/bin:$SNAP/bin\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" $*\n')
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -356,7 +356,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
             '\n\n'
             'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
             'exec "$SNAP/snap_exe"'
-            ' "$SNAP/test_relexepath" $*\n')
+            ' "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -383,7 +383,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         expected = ('#!/bin/sh\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" $*\n')
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -410,7 +410,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         expected = ('#!/bin/sh\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "$SNAP/test_relexepath" $*\n')
+                    'exec "$SNAP/test_relexepath" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 
@@ -430,7 +430,7 @@ PATH={0}/part1/install/usr/bin:{0}/part1/install/bin
         expected = ('#!/bin/sh\n'
                     '\n\n'
                     'LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH\n'
-                    'exec "app1" $*\n')
+                    'exec "app1" "$@"\n')
         with open(wrapper_path) as wrapper_file:
             wrapper_contents = wrapper_file.read()
 


### PR DESCRIPTION
"$@" is the proper way to expand original positional args; $* will
perform an extra IFS split.

LP: #1572129

Signed-off-by: Loïc Minier <loic.minier@ubuntu.com>
Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>