### PR TITLE
Use colors for logging.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -93,17 +93,9 @@ class TestCase(testtools.TestCase):
             "One-time password (just press enter if you don't use two-factor "
             "authentication): ")
         process.sendline('')
-        process.expect_exact(
-            # bold.
-            '\r\n\x1b[1m'
-            'Authenticating against Ubuntu One SSO.'
-            '\x1b[0m\r\n')
+        process.expect_exact('Authenticating against Ubuntu One SSO.')
         result = 'successful' if expect_success else 'failed'
-        process.expect_exact(
-            # bold.
-            '\x1b[1m'
-            'Login {}.'.format(result) +
-            '\x1b[0m\r\n')
+        process.expect_exact('Login {}.'.format(result))
 
     def logout(self):
         output = self.run_snapcraft('logout')

--- a/snapcraft/internal/log.py
+++ b/snapcraft/internal/log.py
@@ -34,8 +34,8 @@ class _StderrFilter(logging.Filter):
 
 
 class _ColoredFormatter(logging.Formatter):
-    reset = '\033[0m'
-    level_colors = {
+    RESET = '\033[0m'
+    LEVEL_COLORS = {
         'INFO': '\033[0;32m',  # Green
         'WARNING': '\033[1;33m',  # Yellow
         'ERROR': '\033[0;31m',  # Dark red
@@ -43,11 +43,11 @@ class _ColoredFormatter(logging.Formatter):
     }
 
     def format(self, record):
-        color = self.level_colors.get(record.levelname, None)
+        color = self.LEVEL_COLORS.get(record.levelname, None)
         log_message = super().format(record)
         if color:
             return '{color}{message}{reset}'.format(
-                color=color, message=log_message, reset=self.reset)
+                color=color, message=log_message, reset=self.RESET)
 
         return log_message
 

--- a/snapcraft/tests/test_log.py
+++ b/snapcraft/tests/test_log.py
@@ -30,10 +30,10 @@ class LogTestCase(tests.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.info_color = log._ColoredFormatter.level_colors['INFO']
-        self.warning_color = log._ColoredFormatter.level_colors['WARNING']
-        self.error_color = log._ColoredFormatter.level_colors['ERROR']
-        self.critical_color = log._ColoredFormatter.level_colors['CRITICAL']
+        self.info_color = log._ColoredFormatter.LEVEL_COLORS['INFO']
+        self.warning_color = log._ColoredFormatter.LEVEL_COLORS['WARNING']
+        self.error_color = log._ColoredFormatter.LEVEL_COLORS['ERROR']
+        self.critical_color = log._ColoredFormatter.LEVEL_COLORS['CRITICAL']
 
     def test_configure_must_send_messages_to_stdout(
             self, mock_stderr, mock_stdout, mock_isatty):

--- a/snapcraft/tests/test_log.py
+++ b/snapcraft/tests/test_log.py
@@ -27,6 +27,14 @@ from snapcraft import tests
 @mock.patch('sys.stderr', new_callable=io.StringIO)
 class LogTestCase(tests.TestCase):
 
+    def setUp(self):
+        super().setUp()
+
+        self.info_color = log._ColoredFormatter.level_colors['INFO']
+        self.warning_color = log._ColoredFormatter.level_colors['WARNING']
+        self.error_color = log._ColoredFormatter.level_colors['ERROR']
+        self.critical_color = log._ColoredFormatter.level_colors['CRITICAL']
+
     def test_configure_must_send_messages_to_stdout(
             self, mock_stderr, mock_stdout, mock_isatty):
         logger_name = self.id()
@@ -39,10 +47,10 @@ class LogTestCase(tests.TestCase):
         logger.info('Test info')
         logger.warning('Test warning')
 
-        expected_out = (
-            '\033[1mTest debug\033[0m\n'
-            '\033[1mTest info\033[0m\n'
-            '\033[1mTest warning\033[0m\n')
+        expected_out = ('Test debug\n'
+                        '{}Test info\033[0m\n'
+                        '{}Test warning\033[0m\n').format(
+            self.info_color, self.warning_color)
         self.assertEqual(expected_out, mock_stdout.getvalue())
         self.assertEqual('', mock_stderr.getvalue())
 
@@ -57,9 +65,9 @@ class LogTestCase(tests.TestCase):
         logger.error('Test error')
         logger.critical('Test critical')
 
-        expected_err = (
-            '\033[1mTest error\033[0m\n'
-            '\033[1mTest critical\033[0m\n')
+        expected_err = ('{}Test error\033[0m\n'
+                        '{}Test critical\033[0m\n').format(
+            self.error_color, self.critical_color)
         self.assertEqual(expected_err, mock_stderr.getvalue())
         self.assertEqual('', mock_stdout.getvalue())
 
@@ -75,12 +83,12 @@ class LogTestCase(tests.TestCase):
         logger.error('Test error')
         logger.critical('Test critical')
 
-        expected_out = (
-            '\033[1mTest info\033[0m\n'
-            '\033[1mTest warning\033[0m\n')
-        expected_err = (
-            '\033[1mTest error\033[0m\n'
-            '\033[1mTest critical\033[0m\n')
+        expected_out = ('{}Test info\033[0m\n'
+                        '{}Test warning\033[0m\n').format(
+            self.info_color, self.warning_color)
+        expected_err = ('{}Test error\033[0m\n'
+                        '{}Test critical\033[0m\n').format(
+            self.error_color, self.critical_color)
         self.assertEqual(expected_out, mock_stdout.getvalue())
         self.assertEqual(expected_err, mock_stderr.getvalue())
 
@@ -96,12 +104,35 @@ class LogTestCase(tests.TestCase):
         logger.error('Test error')
         logger.critical('Test critical')
 
-        expected_out = (
-            '\033[1mTest debug\033[0m\n'
-            '\033[1mTest info\033[0m\n'
-            '\033[1mTest warning\033[0m\n')
-        expected_err = (
-            '\033[1mTest error\033[0m\n'
-            '\033[1mTest critical\033[0m\n')
+        expected_out = ('Test debug\n'
+                        '{}Test info\033[0m\n'
+                        '{}Test warning\033[0m\n').format(
+            self.info_color, self.warning_color)
+        expected_err = ('{}Test error\033[0m\n'
+                        '{}Test critical\033[0m\n').format(
+            self.error_color, self.critical_color)
+        self.assertEqual(expected_out, mock_stdout.getvalue())
+        self.assertEqual(expected_err, mock_stderr.getvalue())
+
+    def test_configure_must_support_no_tty(
+            self, mock_stderr, mock_stdout, mock_isatty):
+        mock_isatty.return_value = False
+        logger_name = self.id()
+        log.configure(logger_name, log_level=logging.DEBUG)
+        logger = logging.getLogger(logger_name)
+
+        logger.debug('Test debug')
+        logger.info('Test info')
+        logger.warning('Test warning')
+        logger.error('Test error')
+        logger.critical('Test critical')
+
+        expected_out = ('Test debug\n'
+                        'Test info\n'
+                        'Test warning\n').format(
+            self.info_color, self.warning_color)
+        expected_err = ('Test error\n'
+                        'Test critical\n').format(
+            self.error_color, self.critical_color)
         self.assertEqual(expected_out, mock_stdout.getvalue())
         self.assertEqual(expected_err, mock_stderr.getvalue())


### PR DESCRIPTION
This fixes LP: [#1572186](https://bugs.launchpad.net/snapcraft/+bug/1572186) by using the following colors:

  - INFO: Green
  - WARNING: Yellow
  - ERROR: Dark red
  - CRITICAL: Light red