### PR TITLE
Make upload more robust by ignoring suprious errors while polling the…

### DIFF
--- a/snapcraft/storeapi/common.py
+++ b/snapcraft/storeapi/common.py
@@ -67,13 +67,6 @@ def store_api_call(path, session=None, method='GET', data=None):
     return result
 
 
-def is_scan_completed(response):
-    """Return True if the response indicates the scan process completed."""
-    if response.ok:
-        return response.json().get('completed', False)
-    return False
-
-
 def retry(terminator=None, retries=3, delay=3, backoff=2, logger=None):
     """Decorate a function to automatically retry calling it on failure.
 


### PR DESCRIPTION
… scan status.

While the snap is scanned on the store, the status is polled until completion.

If an error occurs while acquiring the status, ignore the errors.

Those errors are rare and the next retry generally succeeds so ignoring those errors is harmless.

If they persist until the last retry, something else may be going on and this will still be reported.

LP: #1572963