### PR TITLE
Add support for confinement property.

### DIFF
--- a/docs/ros-snap.md
+++ b/docs/ros-snap.md
@@ -266,6 +266,7 @@ name: ros-example
 version: 1.0
 summary: ROS Example
 description: Contains talker/listener ROS packages and a .launch file.
+confinement: strict
 
 apps:
   launch-project:

--- a/docs/snapcraft-syntax.md
+++ b/docs/snapcraft-syntax.md
@@ -17,9 +17,10 @@ contain.
 * `description` (string)
   The description for the snap, this can and is expected to be a longer
   explanation for the snap.
-* `config` (string)
-  Path to the runnable in snap that will be used as the [Snappy config
-  interface](https://developer.ubuntu.com/snappy/guides/config-command/).
+* `confinement` (string)
+  The type of confinement supported by the snap. Can be either "devmode" (i.e.
+  this snap doesn't support running under confinement) or "strict" (i.e. full
+  confinement supported via interfaces).
 * `apps` (yaml subsection)
   A map of keys for applications. These are either daemons or command line
   accessible binaries.

--- a/docs/your-first-snap.md
+++ b/docs/your-first-snap.md
@@ -79,6 +79,7 @@ name: webcam-webui
 version: 1
 summary: Webcam web UI
 description: Exposes your webcam over a web UI
+confinement: strict
 ```
 
 If you run `snapcraft snap` now, it will complain about not having any `parts`.
@@ -263,6 +264,7 @@ version: 1
 summary: Webcam web UI
 description: Exposes your webcam over a web UI
 icon: icon.png
+confinement: strict
 
 apps:
   webcam-webui:

--- a/examples/96boards-kernel/snapcraft.yaml
+++ b/examples/96boards-kernel/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 4.4.0
 summary: A 96boards kernel built from source
 description: This is the reference kernel from 96boards
 type: kernel
+confinement: enabled
 
 parts:
   kernel:

--- a/examples/96boards-kernel/snapcraft.yaml
+++ b/examples/96boards-kernel/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 4.4.0
 summary: A 96boards kernel built from source
 description: This is the reference kernel from 96boards
 type: kernel
-confinement: enabled
+confinement: strict
 
 parts:
   kernel:

--- a/examples/busybox/snapcraft.yaml
+++ b/examples/busybox/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: busybox example to showcase the snapcraft kbuild plugin
 description:
    this is a snapcraft example package that contains the output of the
    snapcraft busybox example.
+confinement: enabled
 
 apps:
   ls:

--- a/examples/busybox/snapcraft.yaml
+++ b/examples/busybox/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: busybox example to showcase the snapcraft kbuild plugin
 description:
    this is a snapcraft example package that contains the output of the
    snapcraft busybox example.
-confinement: enabled
+confinement: strict
 
 apps:
   ls:

--- a/examples/downloader-with-wiki-parts/snapcraft.yaml
+++ b/examples/downloader-with-wiki-parts/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 1.0
 summary: curl based downloader
 description: this is an example package
 icon: icon.png
+confinement: enabled
 apps:
     test:
         command: bin/test

--- a/examples/downloader-with-wiki-parts/snapcraft.yaml
+++ b/examples/downloader-with-wiki-parts/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 1.0
 summary: curl based downloader
 description: this is an example package
 icon: icon.png
-confinement: enabled
+confinement: strict
 apps:
     test:
         command: bin/test

--- a/examples/git/snapcraft.yaml
+++ b/examples/git/snapcraft.yaml
@@ -2,10 +2,11 @@ name: git
 version: 2.8.0
 summary: Git is a free and open source distributed version control system.
 description: This example is not really production quality
+confinement: enabled
 
 apps:
   server:
-    command: bin/git 
+    command: bin/git
 
 parts:
   git:

--- a/examples/git/snapcraft.yaml
+++ b/examples/git/snapcraft.yaml
@@ -2,7 +2,7 @@ name: git
 version: 2.8.0
 summary: Git is a free and open source distributed version control system.
 description: This example is not really production quality
-confinement: enabled
+confinement: strict
 
 apps:
   server:

--- a/examples/godd/snapcraft.yaml
+++ b/examples/godd/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Simple dd like tool
 description:
  Written in go with support for device auto-detection via libgudev,
  you would need to use hw-assign to access devices.
-confinement: enabled
+confinement: strict
 
 apps:
   godd:

--- a/examples/godd/snapcraft.yaml
+++ b/examples/godd/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Simple dd like tool
 description:
  Written in go with support for device auto-detection via libgudev,
  you would need to use hw-assign to access devices.
+confinement: enabled
 
 apps:
   godd:

--- a/examples/gopaste/snapcraft.yaml
+++ b/examples/gopaste/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 1.0
 summary: Simple pasting tool
 description: Runs a service that allows you to paste to and share.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   gopaste:

--- a/examples/gopaste/snapcraft.yaml
+++ b/examples/gopaste/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 1.0
 summary: Simple pasting tool
 description: Runs a service that allows you to paste to and share.
 icon: icon.png
+confinement: enabled
 
 apps:
   gopaste:

--- a/examples/java-hello-world/snapcraft.yaml
+++ b/examples/java-hello-world/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0
 summary: A java example
 description: this is not much more than an example
 icon: icon.png
+confinement: enabled
 
 apps:
  hello:

--- a/examples/java-hello-world/snapcraft.yaml
+++ b/examples/java-hello-world/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0
 summary: A java example
 description: this is not much more than an example
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
  hello:

--- a/examples/libpipeline/snapcraft.yaml
+++ b/examples/libpipeline/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   This is an example package of an autotools project built with snapcraft
   using a remote source.
 icon: icon.png
+confinement: enabled
 
 apps:
   pipelinetest:

--- a/examples/libpipeline/snapcraft.yaml
+++ b/examples/libpipeline/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   This is an example package of an autotools project built with snapcraft
   using a remote source.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   pipelinetest:

--- a/examples/mosquitto/snapcraft.yaml
+++ b/examples/mosquitto/snapcraft.yaml
@@ -2,6 +2,7 @@ name: mosquitto
 version: 0.1
 summary: mosquitto server and client
 description: MQTT example with a server, a publisher and a subscriber.
+confinement: enabled
 
 apps:
   mosquitto:

--- a/examples/mosquitto/snapcraft.yaml
+++ b/examples/mosquitto/snapcraft.yaml
@@ -2,7 +2,7 @@ name: mosquitto
 version: 0.1
 summary: mosquitto server and client
 description: MQTT example with a server, a publisher and a subscriber.
-confinement: enabled
+confinement: strict
 
 apps:
   mosquitto:

--- a/examples/opencv/snapcraft.yaml
+++ b/examples/opencv/snapcraft.yaml
@@ -2,7 +2,7 @@ name: opencv-example
 version: 1.0
 summary: Use OpenCV and OpenGL
 description: A simple OpenCV example
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, g++, libc6-dev, libopencv-dev]
 

--- a/examples/opencv/snapcraft.yaml
+++ b/examples/opencv/snapcraft.yaml
@@ -2,6 +2,7 @@ name: opencv-example
 version: 1.0
 summary: Use OpenCV and OpenGL
 description: A simple OpenCV example
+confinement: enabled
 
 build-packages: [gcc, g++, libc6-dev, libopencv-dev]
 

--- a/examples/py2-project/snapcraft.yaml
+++ b/examples/py2-project/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0
 summary: A python sha3 implementation
 description: A python2 project using snapcraft
 icon: icon.png
+confinement: enabled
 
 apps:
   sha3sum:

--- a/examples/py2-project/snapcraft.yaml
+++ b/examples/py2-project/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0
 summary: A python sha3 implementation
 description: A python2 project using snapcraft
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   sha3sum:

--- a/examples/py3-project/snapcraft.yaml
+++ b/examples/py3-project/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0
 summary: A python sha3 implementation
 description: A python2 project using snapcraft
 icon: icon.png
+confinement: enabled
 
 apps:
   sha3sum:

--- a/examples/py3-project/snapcraft.yaml
+++ b/examples/py3-project/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0
 summary: A python sha3 implementation
 description: A python2 project using snapcraft
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   sha3sum:

--- a/examples/ros/snapcraft.yaml
+++ b/examples/ros/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ros-example
 version: 1.0
 summary: ROS Example
 description: Contains talker/listener ROS packages and a .launch file.
-confinement: enabled
+confinement: strict
 
 apps:
   launch-project:

--- a/examples/ros/snapcraft.yaml
+++ b/examples/ros/snapcraft.yaml
@@ -2,6 +2,7 @@ name: ros-example
 version: 1.0
 summary: ROS Example
 description: Contains talker/listener ROS packages and a .launch file.
+confinement: enabled
 
 apps:
   launch-project:

--- a/examples/shout/snapcraft.yaml
+++ b/examples/shout/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.52.0
 summary: A self hosted web IRC client
 description: This example is not really production quality
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   server:

--- a/examples/shout/snapcraft.yaml
+++ b/examples/shout/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.52.0
 summary: A self hosted web IRC client
 description: This example is not really production quality
 icon: icon.png
+confinement: enabled
 
 apps:
   server:

--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -5,6 +5,7 @@ architectures:
 summary: Demo of Tomcat-hosted Webapp
 description: This is a demo snap of a Tomcat-hosted webapp produced by snapcraft with maven.
 icon: icon.png
+confinement: enabled
 
 apps:
  tomcat:

--- a/examples/tomcat-maven-webapp/snapcraft.yaml
+++ b/examples/tomcat-maven-webapp/snapcraft.yaml
@@ -5,7 +5,7 @@ architectures:
 summary: Demo of Tomcat-hosted Webapp
 description: This is a demo snap of a Tomcat-hosted webapp produced by snapcraft with maven.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
  tomcat:

--- a/examples/webcam-webui/snapcraft.yaml
+++ b/examples/webcam-webui/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 1
 summary: Webcam web UI
 description: Exposes your webcam over a web UI
 icon: icon.png
+confinement: enabled
 
 apps:
   webcam-webui:

--- a/examples/webcam-webui/snapcraft.yaml
+++ b/examples/webcam-webui/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 1
 summary: Webcam web UI
 description: Exposes your webcam over a web UI
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   webcam-webui:

--- a/examples/webchat/snapcraft.yaml
+++ b/examples/webchat/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.0.1
 summary: A simple nodejs based webchat
 description: This example is not really production quality
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   webchat:

--- a/examples/webchat/snapcraft.yaml
+++ b/examples/webchat/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.0.1
 summary: A simple nodejs based webchat
 description: This example is not really production quality
 icon: icon.png
+confinement: enabled
 
 apps:
   webchat:

--- a/integration_tests/snaps/assemble/snapcraft.yaml
+++ b/integration_tests/snaps/assemble/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 1.0
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 apps:
   assemble-bin:

--- a/integration_tests/snaps/assemble/snapcraft.yaml
+++ b/integration_tests/snaps/assemble/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 1.0
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 apps:
   assemble-bin:

--- a/integration_tests/snaps/basic/snapcraft.yaml
+++ b/integration_tests/snaps/basic/snapcraft.yaml
@@ -2,7 +2,7 @@ name: basic
 version: 0.1
 summary: Summary of the most simple snap
 description: Description of the most simple snap
-confinement: enabled
+confinement: strict
 
 parts:
   dummy-part:

--- a/integration_tests/snaps/basic/snapcraft.yaml
+++ b/integration_tests/snaps/basic/snapcraft.yaml
@@ -2,6 +2,7 @@ name: basic
 version: 0.1
 summary: Summary of the most simple snap
 description: Description of the most simple snap
+confinement: enabled
 
 parts:
   dummy-part:

--- a/integration_tests/snaps/bzr-head/snapcraft.yaml
+++ b/integration_tests/snaps/bzr-head/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     bzr:

--- a/integration_tests/snaps/bzr-head/snapcraft.yaml
+++ b/integration_tests/snaps/bzr-head/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     bzr:

--- a/integration_tests/snaps/bzr-tag/snapcraft.yaml
+++ b/integration_tests/snaps/bzr-tag/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     bzr:

--- a/integration_tests/snaps/bzr-tag/snapcraft.yaml
+++ b/integration_tests/snaps/bzr-tag/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     bzr:

--- a/integration_tests/snaps/conflicts/snapcraft.yaml
+++ b/integration_tests/snaps/conflicts/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/conflicts/snapcraft.yaml
+++ b/integration_tests/snaps/conflicts/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/copy-with-source/snapcraft.yaml
+++ b/integration_tests/snaps/copy-with-source/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: A test of the copy plugin
 description: |
     Copies a file and a directory into our final output using the source
     keyword. The test verifies they're there.
+confinement: enabled
 
 parts:
   copy-example:

--- a/integration_tests/snaps/copy-with-source/snapcraft.yaml
+++ b/integration_tests/snaps/copy-with-source/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: A test of the copy plugin
 description: |
     Copies a file and a directory into our final output using the source
     keyword. The test verifies they're there.
-confinement: enabled
+confinement: strict
 
 parts:
   copy-example:

--- a/integration_tests/snaps/dependencies/snapcraft.yaml
+++ b/integration_tests/snaps/dependencies/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/dependencies/snapcraft.yaml
+++ b/integration_tests/snaps/dependencies/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/framework-policy/snapcraft.yaml
+++ b/integration_tests/snaps/framework-policy/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 framework-policy: dir
-confinement: enabled
+confinement: strict
 
 parts:
     framework-project:

--- a/integration_tests/snaps/framework-policy/snapcraft.yaml
+++ b/integration_tests/snaps/framework-policy/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: one line summary
 description: a longer description
 icon: icon.png
 framework-policy: dir
+confinement: enabled
 
 parts:
     framework-project:

--- a/integration_tests/snaps/git-branch/snapcraft.yaml
+++ b/integration_tests/snaps/git-branch/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     git:

--- a/integration_tests/snaps/git-branch/snapcraft.yaml
+++ b/integration_tests/snaps/git-branch/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     git:

--- a/integration_tests/snaps/git-head/snapcraft.yaml
+++ b/integration_tests/snaps/git-head/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     git:

--- a/integration_tests/snaps/git-head/snapcraft.yaml
+++ b/integration_tests/snaps/git-head/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     git:

--- a/integration_tests/snaps/git-tag/snapcraft.yaml
+++ b/integration_tests/snaps/git-tag/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     git:

--- a/integration_tests/snaps/git-tag/snapcraft.yaml
+++ b/integration_tests/snaps/git-tag/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     git:

--- a/integration_tests/snaps/hg-branch/snapcraft.yaml
+++ b/integration_tests/snaps/hg-branch/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     mercurial:

--- a/integration_tests/snaps/hg-branch/snapcraft.yaml
+++ b/integration_tests/snaps/hg-branch/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     mercurial:

--- a/integration_tests/snaps/hg-head/snapcraft.yaml
+++ b/integration_tests/snaps/hg-head/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     mercurial:

--- a/integration_tests/snaps/hg-head/snapcraft.yaml
+++ b/integration_tests/snaps/hg-head/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     mercurial:

--- a/integration_tests/snaps/hg-tag/snapcraft.yaml
+++ b/integration_tests/snaps/hg-tag/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     mercurial:

--- a/integration_tests/snaps/hg-tag/snapcraft.yaml
+++ b/integration_tests/snaps/hg-tag/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     mercurial:

--- a/integration_tests/snaps/independent-parts/snapcraft.yaml
+++ b/integration_tests/snaps/independent-parts/snapcraft.yaml
@@ -2,6 +2,7 @@ name: independent-parts
 version: 1
 summary: Two independent parts
 description: Two independent parts
+confinement: enabled
 
 parts:
   part1:

--- a/integration_tests/snaps/independent-parts/snapcraft.yaml
+++ b/integration_tests/snaps/independent-parts/snapcraft.yaml
@@ -2,7 +2,7 @@ name: independent-parts
 version: 1
 summary: Two independent parts
 description: Two independent parts
-confinement: enabled
+confinement: strict
 
 parts:
   part1:

--- a/integration_tests/snaps/license/snapcraft.yaml
+++ b/integration_tests/snaps/license/snapcraft.yaml
@@ -5,7 +5,7 @@ description:
   This test will grab the defined license and set it up appropriately
   as a hook.
 license: LICENSE
-confinement: enabled
+confinement: strict
 
 parts:
     nothing:

--- a/integration_tests/snaps/license/snapcraft.yaml
+++ b/integration_tests/snaps/license/snapcraft.yaml
@@ -5,6 +5,7 @@ description:
   This test will grab the defined license and set it up appropriately
   as a hook.
 license: LICENSE
+confinement: enabled
 
 parts:
     nothing:

--- a/integration_tests/snaps/local-plugin/snapcraft.yaml
+++ b/integration_tests/snaps/local-plugin/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     x-local-plugin:

--- a/integration_tests/snaps/local-plugin/snapcraft.yaml
+++ b/integration_tests/snaps/local-plugin/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     x-local-plugin:

--- a/integration_tests/snaps/local-source/snapcraft.yaml
+++ b/integration_tests/snaps/local-source/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 parts:
     make-project:

--- a/integration_tests/snaps/local-source/snapcraft.yaml
+++ b/integration_tests/snaps/local-source/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     make-project:

--- a/integration_tests/snaps/nil-plugin-pkgfilter/snapcraft.yaml
+++ b/integration_tests/snaps/nil-plugin-pkgfilter/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
  network-manager is staged and then whitelist filtered for the files required
  in the snap.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     nm-tools:

--- a/integration_tests/snaps/nil-plugin-pkgfilter/snapcraft.yaml
+++ b/integration_tests/snaps/nil-plugin-pkgfilter/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
  network-manager is staged and then whitelist filtered for the files required
  in the snap.
 icon: icon.png
+confinement: enabled
 
 parts:
     nm-tools:

--- a/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
+++ b/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
@@ -2,6 +2,7 @@ name: test-package
 version: 0.1
 summary: Use source with nil
 description: Use source with nil (which should error out)
+confinement: enabled
 
 parts:
     nil-part:

--- a/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
+++ b/integration_tests/snaps/nil-with-additional-properties/snapcraft.yaml
@@ -2,7 +2,7 @@ name: test-package
 version: 0.1
 summary: Use source with nil
 description: Use source with nil (which should error out)
-confinement: enabled
+confinement: strict
 
 parts:
     nil-part:

--- a/integration_tests/snaps/pip-requirements-file/snapcraft.yaml
+++ b/integration_tests/snaps/pip-requirements-file/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   as a requirements.txt file with the list of packages
   that will be downloaded using pip.
 icon: icon.svg
+confinement: enabled
 
 parts:
   python2:

--- a/integration_tests/snaps/pip-requirements-file/snapcraft.yaml
+++ b/integration_tests/snaps/pip-requirements-file/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   as a requirements.txt file with the list of packages
   that will be downloaded using pip.
 icon: icon.svg
-confinement: enabled
+confinement: strict
 
 parts:
   python2:

--- a/integration_tests/snaps/pip-requirements-list/snapcraft.yaml
+++ b/integration_tests/snaps/pip-requirements-list/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   as a list of package names that will be downloaded
   using pip.
 icon: icon.svg
-confinement: enabled
+confinement: strict
 
 parts:
   python2:

--- a/integration_tests/snaps/pip-requirements-list/snapcraft.yaml
+++ b/integration_tests/snaps/pip-requirements-list/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   as a list of package names that will be downloaded
   using pip.
 icon: icon.svg
+confinement: enabled
 
 parts:
   python2:

--- a/integration_tests/snaps/simple-circle/circle/snapcraft.yaml
+++ b/integration_tests/snaps/simple-circle/circle/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
     accept this snapcraft.yaml.
 version: 1.0
 icon: icon.svg
+confinement: enabled
 
 parts:
     a:

--- a/integration_tests/snaps/simple-circle/circle/snapcraft.yaml
+++ b/integration_tests/snaps/simple-circle/circle/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
     accept this snapcraft.yaml.
 version: 1.0
 icon: icon.svg
-confinement: enabled
+confinement: strict
 
 parts:
     a:

--- a/integration_tests/snaps/simple-circle/tree/snapcraft.yaml
+++ b/integration_tests/snaps/simple-circle/tree/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
     code in Snapcraft.
 version: 1.0
 icon: icon.svg
-confinement: enabled
+confinement: strict
 
 parts:
     root:

--- a/integration_tests/snaps/simple-circle/tree/snapcraft.yaml
+++ b/integration_tests/snaps/simple-circle/tree/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
     code in Snapcraft.
 version: 1.0
 icon: icon.svg
+confinement: enabled
 
 parts:
     root:

--- a/integration_tests/snaps/simple-cmake/snapcraft.yaml
+++ b/integration_tests/snaps/simple-cmake/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-cmake/snapcraft.yaml
+++ b/integration_tests/snaps/simple-cmake/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-copy/snapcraft.yaml
+++ b/integration_tests/snaps/simple-copy/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
     Copies a file and a directory src and srcdir respectively into
     our final output. The test verifies they're there.
 icon: icon.png
+confinement: enabled
 
 parts:
   copy-example:

--- a/integration_tests/snaps/simple-copy/snapcraft.yaml
+++ b/integration_tests/snaps/simple-copy/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
     Copies a file and a directory src and srcdir respectively into
     our final output. The test verifies they're there.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   copy-example:

--- a/integration_tests/snaps/simple-go/snapcraft.yaml
+++ b/integration_tests/snaps/simple-go/snapcraft.yaml
@@ -6,6 +6,7 @@ description: |
   The name of the binary will be that of the directory containing it,
   just like it is seen when using `go build` or `go install`.
 icon: icon.png
+confinement: enabled
 
 parts:
   simple-go:

--- a/integration_tests/snaps/simple-go/snapcraft.yaml
+++ b/integration_tests/snaps/simple-go/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   The name of the binary will be that of the directory containing it,
   just like it is seen when using `go build` or `go install`.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   simple-go:

--- a/integration_tests/snaps/simple-make-filesets/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-filesets/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: Use organized filesets
 description: organize the filesets before staging them
 icon: icon.png
+confinement: enabled
 
 parts:
   make-project:

--- a/integration_tests/snaps/simple-make-filesets/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-filesets/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: Use organized filesets
 description: organize the filesets before staging them
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   make-project:

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
@@ -2,7 +2,7 @@ name: test-package
 version: 0.1
 summary: one line summary
 description: a longer description
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make-nonstandard-makefile/snapcraft.yaml
@@ -2,6 +2,7 @@ name: test-package
 version: 0.1
 summary: one line summary
 description: a longer description
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-make/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-make/snapcraft.yaml
+++ b/integration_tests/snaps/simple-make/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-maven/snapcraft.yaml
+++ b/integration_tests/snaps/simple-maven/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
  Test maven builds and options. If the tests aren't skipped we will run into
  the assertTrue ( false ) statement and the build will fail.
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   m:

--- a/integration_tests/snaps/simple-maven/snapcraft.yaml
+++ b/integration_tests/snaps/simple-maven/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
  Test maven builds and options. If the tests aren't skipped we will run into
  the assertTrue ( false ) statement and the build will fail.
 icon: icon.png
+confinement: enabled
 
 parts:
   m:

--- a/integration_tests/snaps/simple-nil/snapcraft.yaml
+++ b/integration_tests/snaps/simple-nil/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: Create the empty snap
 description: Create an empty snap with nothing to pull
 icon: icon.png
+confinement: enabled
 
 parts:
     nil-part:

--- a/integration_tests/snaps/simple-nil/snapcraft.yaml
+++ b/integration_tests/snaps/simple-nil/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: Create the empty snap
 description: Create an empty snap with nothing to pull
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
     nil-part:

--- a/integration_tests/snaps/simple-nodejs/snapcraft.yaml
+++ b/integration_tests/snaps/simple-nodejs/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: A simple nodejs project.
 description: |
   Proves that it is possible to build a snap using local nodejs sources.
+confinement: enabled
 
 parts:
   simple-nodejs:

--- a/integration_tests/snaps/simple-nodejs/snapcraft.yaml
+++ b/integration_tests/snaps/simple-nodejs/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: A simple nodejs project.
 description: |
   Proves that it is possible to build a snap using local nodejs sources.
-confinement: enabled
+confinement: strict
 
 parts:
   simple-nodejs:

--- a/integration_tests/snaps/simple-scons/snapcraft.yaml
+++ b/integration_tests/snaps/simple-scons/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: test a simple scons project
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-scons/snapcraft.yaml
+++ b/integration_tests/snaps/simple-scons/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: test a simple scons project
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-tar/snapcraft.yaml
+++ b/integration_tests/snaps/simple-tar/snapcraft.yaml
@@ -3,7 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/simple-tar/snapcraft.yaml
+++ b/integration_tests/snaps/simple-tar/snapcraft.yaml
@@ -3,6 +3,7 @@ version: 0.1
 summary: one line summary
 description: a longer description
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc, libc6-dev]
 

--- a/integration_tests/snaps/stage_env/snapcraft.yaml
+++ b/integration_tests/snaps/stage_env/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: try out $SNAPCRAFT_STAGE
 description: |
   The cmake-project expects to have a copied directory in the stage directory
   to consume during its build time.
+confinement: enabled
 
 parts:
   cmake-project:

--- a/integration_tests/snaps/stage_env/snapcraft.yaml
+++ b/integration_tests/snaps/stage_env/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: try out $SNAPCRAFT_STAGE
 description: |
   The cmake-project expects to have a copied directory in the stage directory
   to consume during its build time.
-confinement: enabled
+confinement: strict
 
 parts:
   cmake-project:

--- a/integration_tests/snaps/wiki/snapcraft.yaml
+++ b/integration_tests/snaps/wiki/snapcraft.yaml
@@ -9,6 +9,7 @@ description:
  In this case the wiki defines it wants curl 7.44.0 and we are telling
  it to use 7.45.0
 icon: icon.png
+confinement: enabled
 
 build-packages: [gcc]
 

--- a/integration_tests/snaps/wiki/snapcraft.yaml
+++ b/integration_tests/snaps/wiki/snapcraft.yaml
@@ -9,7 +9,7 @@ description:
  In this case the wiki defines it wants curl 7.44.0 and we are telling
  it to use 7.45.0
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 build-packages: [gcc]
 

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,6 +63,7 @@ properties:
   confinement:
     type: string
     description: the type of confinement supported by the snap
+    default: strict
     enum:
       - devmode
       - strict
@@ -184,7 +185,6 @@ required:
   - version
   - summary
   - description
-  - confinement
   - parts
 dependencies:
   license-agreement: ["license"]

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -60,6 +60,12 @@ properties:
       - explicit
   license-version:
     description: license version (used to re-trigger an agreement action).
+  confinement:
+    type: string
+    description: the type of confinement supported by the snap
+    enum:
+      - devmode
+      - enabled
   apps:
     type: object
     additionalProperties: false
@@ -178,6 +184,7 @@ required:
   - version
   - summary
   - description
+  - confinement
   - parts
 dependencies:
   license-agreement: ["license"]

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -65,7 +65,7 @@ properties:
     description: the type of confinement supported by the snap
     enum:
       - devmode
-      - enabled
+      - strict
   apps:
     type: object
     additionalProperties: false

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -41,17 +41,25 @@ class Validator:
         self._load_schema()
 
     @property
+    def schema(self):
+        """Return all schema properties."""
+
+        return self._schema['properties'].copy()
+
+    @property
     def part_schema(self):
-        sub = self.schema['properties']['parts']['patternProperties']
+        """Return part-specific schema properties."""
+
+        sub = self.schema['parts']['patternProperties']
         properties = sub['^(?!plugins$)[a-z0-9][a-z0-9+-]*$']['properties']
-        return properties.copy()
+        return properties
 
     def _load_schema(self):
         schema_file = os.path.abspath(os.path.join(
             common.get_schemadir(), 'snapcraft.yaml'))
         try:
             with open(schema_file) as fp:
-                self.schema = yaml.load(fp)
+                self._schema = yaml.load(fp)
         except FileNotFoundError:
             raise SnapcraftSchemaError(
                 'snapcraft validation file is missing from installation path')
@@ -60,7 +68,7 @@ class Validator:
         format_check = jsonschema.FormatChecker()
         try:
             jsonschema.validate(
-                self._snapcraft, self.schema, format_checker=format_check)
+                self._snapcraft, self._schema, format_checker=format_check)
         except jsonschema.ValidationError as e:
             messages = [e.message]
             if e.path:

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -42,7 +42,7 @@ class Validator:
 
     @property
     def part_schema(self):
-        sub = self._schema['properties']['parts']['patternProperties']
+        sub = self.schema['properties']['parts']['patternProperties']
         properties = sub['^(?!plugins$)[a-z0-9][a-z0-9+-]*$']['properties']
         return properties.copy()
 
@@ -51,7 +51,7 @@ class Validator:
             common.get_schemadir(), 'snapcraft.yaml'))
         try:
             with open(schema_file) as fp:
-                self._schema = yaml.load(fp)
+                self.schema = yaml.load(fp)
         except FileNotFoundError:
             raise SnapcraftSchemaError(
                 'snapcraft validation file is missing from installation path')
@@ -60,7 +60,7 @@ class Validator:
         format_check = jsonschema.FormatChecker()
         try:
             jsonschema.validate(
-                self._snapcraft, self._schema, format_checker=format_check)
+                self._snapcraft, self.schema, format_checker=format_check)
         except jsonschema.ValidationError as e:
             messages = [e.message]
             if e.path:

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -41,7 +41,7 @@ _TEMPLATE_YAML = r'''name: # the name of the snap
 version: # the version of the snap
 summary: # 79 char long summary
 description: # a longer description for the snap
-confinement: devmode # devmode means no confinement is supported
+confinement: devmode # devmode means the snap doesn't support confinement
 '''
 
 _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'strip'}

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -37,12 +37,13 @@ from snapcraft.internal import (
 logger = logging.getLogger(__name__)
 
 
-_TEMPLATE_YAML = r'''name: # the name of the snap
+_TEMPLATE_YAML = """name: # the name of the snap
 version: # the version of the snap
 summary: # 79 char long summary
 description: # a longer description for the snap
-confinement: devmode # devmode means the snap doesn't support confinement
-'''
+confinement: devmode # use "strict" to enforce system access only via \
+declared interfaces
+"""
 
 _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'strip'}
 

--- a/snapcraft/internal/lifecycle.py
+++ b/snapcraft/internal/lifecycle.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 _TEMPLATE_YAML = r'''name: # the name of the snap
 version: # the version of the snap
 summary: # 79 char long summary
-description: # A longer description for the snap
+description: # a longer description for the snap
+confinement: devmode # devmode means no confinement is supported
 '''
 
 _STEPS_TO_AUTOMATICALLY_CLEAN_IF_DIRTY = {'stage', 'strip'}

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -35,6 +35,7 @@ _MANDATORY_PACKAGE_KEYS = [
     'version',
     'description',
     'summary',
+    'confinement'
 ]
 
 _OPTIONAL_PACKAGE_KEYS = [

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -35,7 +35,6 @@ _MANDATORY_PACKAGE_KEYS = [
     'version',
     'description',
     'summary',
-    'confinement'
 ]
 
 _OPTIONAL_PACKAGE_KEYS = [
@@ -45,6 +44,7 @@ _OPTIONAL_PACKAGE_KEYS = [
     'license-version',
     'plugs',
     'slots',
+    'confinement',
 ]
 
 _KERNEL_KEYS = {

--- a/snapcraft/internal/yaml.py
+++ b/snapcraft/internal/yaml.py
@@ -552,5 +552,4 @@ def _ensure_confinement_default(yaml_data, schema):
     if 'confinement' not in yaml_data:
         logger.warning('"confinement" property not specified: defaulting '
                        'to "strict"')
-        properties = schema['properties']['confinement']
-        yaml_data['confinement'] = properties['default']
+        yaml_data['confinement'] = schema['confinement']['default']

--- a/snapcraft/internal/yaml.py
+++ b/snapcraft/internal/yaml.py
@@ -111,6 +111,7 @@ class Config:
 
         self._validator = Validator(self.data)
         self._validator.validate()
+        _ensure_confinement_default(self.data, self._validator.schema)
 
         self.build_tools = self.data.get('build-packages', [])
         self.build_tools.extend(project_options.additional_build_packages)
@@ -543,3 +544,13 @@ def load_config(project_options=None):
     except pluginhandler.PluginError as e:
         logger.error('Issue while loading plugin: {}'.format(e))
         sys.exit(1)
+
+
+def _ensure_confinement_default(yaml_data, schema):
+    # Provide hint if the confinement property is missing, and add the
+    # default. We use the schema here so we don't have to hard-code defaults.
+    if 'confinement' not in yaml_data:
+        logger.warning('"confinement" property not specified: defaulting '
+                       'to "strict"')
+        properties = schema['properties']['confinement']
+        yaml_data['confinement'] = properties['default']

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -42,7 +42,7 @@ version: 1
 summary: test
 description: test
 icon: my-icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   part1:

--- a/snapcraft/tests/test_cmds.py
+++ b/snapcraft/tests/test_cmds.py
@@ -42,6 +42,7 @@ version: 1
 summary: test
 description: test
 icon: my-icon.png
+confinement: enabled
 
 parts:
   part1:

--- a/snapcraft/tests/test_commands_build.py
+++ b/snapcraft/tests/test_commands_build.py
@@ -30,7 +30,7 @@ class BuildCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test build
 description: if the build is succesful the state file will be updated
-confinement: enabled
+confinement: strict
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_build.py
+++ b/snapcraft/tests/test_commands_build.py
@@ -30,6 +30,7 @@ class BuildCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test build
 description: if the build is succesful the state file will be updated
+confinement: enabled
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -34,7 +34,7 @@ version: 1.0
 summary: test clean
 description: if the clean is succesful the state file will be updated
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
 {parts}"""
@@ -176,7 +176,7 @@ class CleanCommandReverseDependenciesTestCase(tests.TestCase):
 version: 1.0
 summary: test clean
 description: test clean
-confinement: enabled
+confinement: strict
 
 parts:
   main:

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -34,6 +34,7 @@ version: 1.0
 summary: test clean
 description: if the clean is succesful the state file will be updated
 icon: icon.png
+confinement: enabled
 
 parts:
 {parts}"""
@@ -175,6 +176,7 @@ class CleanCommandReverseDependenciesTestCase(tests.TestCase):
 version: 1.0
 summary: test clean
 description: test clean
+confinement: enabled
 
 parts:
   main:

--- a/snapcraft/tests/test_commands_cleanbuild.py
+++ b/snapcraft/tests/test_commands_cleanbuild.py
@@ -32,7 +32,7 @@ version: 1.0
 summary: test strip
 description: if snap is succesful a snap package will be available
 architectures: ['amd64']
-confinement: enabled
+confinement: strict
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_cleanbuild.py
+++ b/snapcraft/tests/test_commands_cleanbuild.py
@@ -32,6 +32,7 @@ version: 1.0
 summary: test strip
 description: if snap is succesful a snap package will be available
 architectures: ['amd64']
+confinement: enabled
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_init.py
+++ b/snapcraft/tests/test_commands_init.py
@@ -41,7 +41,7 @@ class InitCommandTestCase(tests.TestCase):
 version: # the version of the snap
 summary: # 79 char long summary
 description: # a longer description for the snap
-confinement: devmode # devmode means no confinement is supported"""
+confinement: devmode # devmode means the snap doesn't support confinement"""
 
         main(['init'])
 

--- a/snapcraft/tests/test_commands_init.py
+++ b/snapcraft/tests/test_commands_init.py
@@ -41,7 +41,8 @@ class InitCommandTestCase(tests.TestCase):
 version: # the version of the snap
 summary: # 79 char long summary
 description: # a longer description for the snap
-confinement: devmode # devmode means the snap doesn't support confinement"""
+confinement: devmode # use "strict" to enforce system access only via \
+declared interfaces"""
 
         main(['init'])
 

--- a/snapcraft/tests/test_commands_init.py
+++ b/snapcraft/tests/test_commands_init.py
@@ -37,6 +37,16 @@ class InitCommandTestCase(tests.TestCase):
         fake_logger = fixtures.FakeLogger(level=logging.INFO)
         self.useFixture(fake_logger)
 
+        expected_yaml = """name: # the name of the snap
+version: # the version of the snap
+summary: # 79 char long summary
+description: # a longer description for the snap
+confinement: devmode # devmode means no confinement is supported"""
+
         main(['init'])
 
         self.assertEqual('Created snapcraft.yaml.\n', fake_logger.output)
+
+        # Verify the generated yaml
+        with open('snapcraft.yaml', 'r') as f:
+            self.assertEqual(f.read(), expected_yaml)

--- a/snapcraft/tests/test_commands_pull.py
+++ b/snapcraft/tests/test_commands_pull.py
@@ -37,6 +37,7 @@ class PullCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test pull
 description: if the pull is succesful the state file will be updated
+confinement: enabled
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_pull.py
+++ b/snapcraft/tests/test_commands_pull.py
@@ -37,7 +37,7 @@ class PullCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test pull
 description: if the pull is succesful the state file will be updated
-confinement: enabled
+confinement: strict
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -33,7 +33,7 @@ summary: test strip
 description: if snap is succesful a snap package will be available
 architectures: ['amd64']
 type: {}
-confinement: enabled
+confinement: strict
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_snap.py
+++ b/snapcraft/tests/test_commands_snap.py
@@ -33,6 +33,7 @@ summary: test strip
 description: if snap is succesful a snap package will be available
 architectures: ['amd64']
 type: {}
+confinement: enabled
 
 parts:
     part1:

--- a/snapcraft/tests/test_commands_stage.py
+++ b/snapcraft/tests/test_commands_stage.py
@@ -30,7 +30,7 @@ class StageCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test stage
 description: if the build is succesful the state file will be updated
-confinement: enabled
+confinement: strict
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_stage.py
+++ b/snapcraft/tests/test_commands_stage.py
@@ -30,6 +30,7 @@ class StageCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test stage
 description: if the build is succesful the state file will be updated
+confinement: enabled
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_strip.py
+++ b/snapcraft/tests/test_commands_strip.py
@@ -30,6 +30,7 @@ class StripCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test strip
 description: if the strip is succesful the state file will be updated
+confinement: enabled
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_commands_strip.py
+++ b/snapcraft/tests/test_commands_strip.py
@@ -30,7 +30,7 @@ class StripCommandTestCase(tests.TestCase):
 version: 1.0
 summary: test strip
 description: if the strip is succesful the state file will be updated
-confinement: enabled
+confinement: strict
 
 parts:
 {parts}"""

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -41,6 +41,7 @@ class ExecutionTestCases(tests.TestCase):
 version: 0
 summary: test
 description: test
+confinement: enabled
 {type}
 
 {parts}

--- a/snapcraft/tests/test_lifecycle.py
+++ b/snapcraft/tests/test_lifecycle.py
@@ -41,7 +41,7 @@ class ExecutionTestCases(tests.TestCase):
 version: 0
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 {type}
 
 {parts}

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -37,6 +37,7 @@ class CreateTest(tests.TestCase):
             'version': '1.0',
             'description': 'my description',
             'summary': 'my summary',
+            'confinement': 'enabled',
         }
 
         self.snap_dir = os.path.join(os.path.abspath(os.curdir), 'snap')
@@ -54,6 +55,7 @@ class CreateTest(tests.TestCase):
             y = yaml.load(f)
 
         expected = {'architectures': ['amd64'],
+                    'confinement': 'enabled',
                     'description': 'my description',
                     'summary': 'my summary',
                     'name': 'my-package',
@@ -258,6 +260,7 @@ class CreateTest(tests.TestCase):
             'summary': 'my summary',
             'name': 'my-package',
             'version': '1.0',
+            'confinement': 'enabled',
             'plugs': {
                 'network-server': {
                     'interface': 'network-bind',

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -37,7 +37,7 @@ class CreateTest(tests.TestCase):
             'version': '1.0',
             'description': 'my description',
             'summary': 'my summary',
-            'confinement': 'enabled',
+            'confinement': 'strict',
         }
 
         self.snap_dir = os.path.join(os.path.abspath(os.curdir), 'snap')
@@ -55,7 +55,7 @@ class CreateTest(tests.TestCase):
             y = yaml.load(f)
 
         expected = {'architectures': ['amd64'],
-                    'confinement': 'enabled',
+                    'confinement': 'strict',
                     'description': 'my description',
                     'summary': 'my summary',
                     'name': 'my-package',
@@ -260,7 +260,7 @@ class CreateTest(tests.TestCase):
             'summary': 'my summary',
             'name': 'my-package',
             'version': '1.0',
-            'confinement': 'enabled',
+            'confinement': 'strict',
             'plugs': {
                 'network-server': {
                     'interface': 'network-bind',

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -37,7 +37,6 @@ class CreateTest(tests.TestCase):
             'version': '1.0',
             'description': 'my description',
             'summary': 'my summary',
-            'confinement': 'strict',
         }
 
         self.snap_dir = os.path.join(os.path.abspath(os.curdir), 'snap')
@@ -55,13 +54,36 @@ class CreateTest(tests.TestCase):
             y = yaml.load(f)
 
         expected = {'architectures': ['amd64'],
-                    'confinement': 'strict',
                     'description': 'my description',
                     'summary': 'my summary',
                     'name': 'my-package',
                     'version': '1.0'}
 
         self.assertEqual(y, expected)
+
+    def test_create_meta_with_confinement(self):
+        confinement_types = [
+            'strict',
+            'devmode',
+        ]
+
+        for confinement_type in confinement_types:
+            with self.subTest(key=confinement_type):
+                self.config_data['confinement'] = confinement_type
+
+                create_snap_packaging(
+                    self.config_data, self.snap_dir, self.parts_dir)
+
+                self.assertTrue(
+                    os.path.exists(self.snap_yaml),
+                    'snap.yaml was not created')
+
+                with open(self.snap_yaml) as f:
+                    y = yaml.load(f)
+                self.assertTrue(
+                    'confinement' in y,
+                    'Expected "confinement" property to be in snap.yaml')
+                self.assertEqual(y['confinement'], confinement_type)
 
     def test_create_meta_with_declared_license(self):
         open(os.path.join(os.curdir, 'LICENSE'), 'w').close()
@@ -260,7 +282,6 @@ class CreateTest(tests.TestCase):
             'summary': 'my summary',
             'name': 'my-package',
             'version': '1.0',
-            'confinement': 'strict',
             'plugs': {
                 'network-server': {
                     'interface': 'network-bind',

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -53,7 +53,7 @@ class TestYaml(tests.TestCase):
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -76,7 +76,7 @@ parts:
 version: "1"
 summary: test
 description: ñoño test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -102,7 +102,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -125,7 +125,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -174,7 +174,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -203,7 +203,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -230,7 +230,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -251,7 +251,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -281,7 +281,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   p1:
@@ -310,7 +310,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -332,7 +332,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -356,7 +356,7 @@ version: "1"
 summary: test
 description: test
 icon: icon.foo
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -381,7 +381,7 @@ version: "1"
 summary: test
 description: test
 icon: icon.png
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -403,7 +403,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -426,7 +426,7 @@ parts:
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -492,13 +492,13 @@ parts:
                 self.assertEqual(
                     raised.exception.message,
                     "The 'confinement' property does not match the required "
-                    "schema: '{}' is not one of ['devmode', 'enabled']".format(
+                    "schema: '{}' is not one of ['devmode', 'strict']".format(
                         confinement_type))
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_yaml_valid_confinement_types(self, mock_loadPlugin):
         valid_confinement_types = [
-            'enabled',
+            'strict',
             'devmode',
         ]
 
@@ -530,7 +530,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
-\tconfinement: enabled
+\tconfinement: strict
 
 parts:
   part1:
@@ -552,7 +552,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -585,7 +585,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   main:
@@ -605,7 +605,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   main:
@@ -631,7 +631,7 @@ class TestYamlEnvironment(tests.TestCase):
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -849,7 +849,7 @@ parts:
 version: "1"
 summary: test
 description: test
-confinement: enabled
+confinement: strict
 
 parts:
   part1:
@@ -963,7 +963,7 @@ class TestValidation(tests.TestCase):
             'version': '1.0-snapcraft1~ppa1',
             'summary': 'my summary less that 79 chars',
             'description': 'description which can be pretty long',
-            'confinement': 'enabled',
+            'confinement': 'strict',
             'parts': {
                 'part1': {
                     'plugin': 'project',

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -53,6 +53,7 @@ class TestYaml(tests.TestCase):
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -75,6 +76,7 @@ parts:
 version: "1"
 summary: test
 description: ñoño test
+confinement: enabled
 
 parts:
   part1:
@@ -100,6 +102,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -122,6 +125,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -170,6 +174,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -198,6 +203,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -224,6 +230,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -244,6 +251,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -273,6 +281,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   p1:
@@ -301,6 +310,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
+confinement: enabled
 
 parts:
   part1:
@@ -322,6 +332,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
+confinement: enabled
 
 parts:
   part1:
@@ -345,6 +356,7 @@ version: "1"
 summary: test
 description: test
 icon: icon.foo
+confinement: enabled
 
 parts:
   part1:
@@ -369,6 +381,7 @@ version: "1"
 summary: test
 description: test
 icon: icon.png
+confinement: enabled
 
 parts:
   part1:
@@ -390,6 +403,7 @@ parts:
 version: "1"
 summary: test
 description: nothing
+confinement: enabled
 
 parts:
   part1:
@@ -412,6 +426,7 @@ parts:
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test
+confinement: enabled
 
 parts:
   part1:
@@ -426,13 +441,96 @@ parts:
             "'description' is a required property")
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_invalid_yaml_missing_confinement(self, mock_loadPlugin):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""")
+        with self.assertRaises(SnapcraftSchemaError) as raised:
+            internal_yaml.Config()
+
+        self.assertEqual(
+            raised.exception.message,
+            "'confinement' is a required property")
+
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_invalid_yaml_invalid_confinement_types(self, mock_loadPlugin):
+        invalid_confinement_types = [
+            'foo',
+            'enabled-',
+            '_devmode',
+        ]
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        for confinement_type in invalid_confinement_types:
+            with self.subTest(key=confinement_type):
+                self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+confinement: {}
+
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""".format(confinement_type))
+                with self.assertRaises(SnapcraftSchemaError) as raised:
+                    internal_yaml.Config()
+
+                self.assertEqual(
+                    raised.exception.message,
+                    "The 'confinement' property does not match the required "
+                    "schema: '{}' is not one of ['devmode', 'enabled']".format(
+                        confinement_type))
+
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_yaml_valid_confinement_types(self, mock_loadPlugin):
+        valid_confinement_types = [
+            'enabled',
+            'devmode',
+        ]
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        for confinement_type in valid_confinement_types:
+            with self.subTest(key=confinement_type):
+                self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+confinement: {}
+
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""".format(confinement_type))
+                c = internal_yaml.Config()
+                self.assertEqual(c.data['confinement'], confinement_type)
+
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_tab_in_yaml(self, mock_loadPlugin):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)
 
         self.make_snapcraft_yaml("""name: test
 version: "1"
-\tsummary: test
+summary: test
+description: nothing
+\tconfinement: enabled
 
 parts:
   part1:
@@ -446,7 +544,7 @@ parts:
         self.assertEqual(
             raised.exception.message,
             'found character \'\\t\' that cannot start any token '
-            'on line 2 of snapcraft.yaml')
+            'on line 4 of snapcraft.yaml')
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_expands_filesets(self, mock_loadPlugin):
@@ -454,6 +552,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -486,6 +585,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   main:
@@ -505,6 +605,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   main:
@@ -530,6 +631,7 @@ class TestYamlEnvironment(tests.TestCase):
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -747,6 +849,7 @@ parts:
 version: "1"
 summary: test
 description: test
+confinement: enabled
 
 parts:
   part1:
@@ -860,6 +963,7 @@ class TestValidation(tests.TestCase):
             'version': '1.0-snapcraft1~ppa1',
             'summary': 'my summary less that 79 chars',
             'description': 'description which can be pretty long',
+            'confinement': 'enabled',
             'parts': {
                 'part1': {
                     'plugin': 'project',

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -441,7 +441,7 @@ parts:
             "'description' is a required property")
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
-    def test_invalid_yaml_missing_confinement(self, mock_loadPlugin):
+    def test_yaml_missing_confinement_must_log(self, mock_loadPlugin):
         fake_logger = fixtures.FakeLogger(level=logging.WARNING)
         self.useFixture(fake_logger)
 

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -466,7 +466,7 @@ parts:
     def test_invalid_yaml_invalid_confinement_types(self, mock_loadPlugin):
         invalid_confinement_types = [
             'foo',
-            'enabled-',
+            'strict-',
             '_devmode',
         ]
 


### PR DESCRIPTION
Snaps need to be able to specify if they require devmode or if they can be run confined. This will allow for snapd to provide reasonable errors if one tries to install a snap that cannot run successfully under
confinement.

This PR resolves LP: [#1580819](https://bugs.launchpad.net/snapcraft/+bug/1580819) by adding the "confinement" property, which must be one of "strict" or "devmode". This property is optional, and defaults to "strict" if unspecified (to maintain backward-compatibility with current behavior). However, `snapcraft init` generates a YAML that sets "confinement" to "devmode" since we expect most snaps to start out needing that.