### PR TITLE
Add support for epoch property.

### DIFF
--- a/docs/snapcraft-syntax.md
+++ b/docs/snapcraft-syntax.md
@@ -17,9 +17,10 @@ contain.
 * `description` (string)
   The description for the snap, this can and is expected to be a longer
   explanation for the snap.
-* `config` (string)
-  Path to the runnable in snap that will be used as the [Snappy config
-  interface](https://developer.ubuntu.com/snappy/guides/config-command/).
+* `epoch` (string)
+  The epoch to which this revision of the snap belongs. This is used to specify
+  upgrade paths. For example, `0` is epoch 0; `1*` is the upgrade path from 0 to
+  1; `1` is epoch 1, etc.
 * `apps` (yaml subsection)
   A map of keys for applications. These are either daemons or command line
   accessible binaries.

--- a/examples/py3-project/snapcraft.yaml
+++ b/examples/py3-project/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: spongeshaker
 version: 0
 summary: A python sha3 implementation
-description: A python2 project using snapcraft
+description: A python3 project using snapcraft
 icon: icon.png
 
 apps:

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -63,9 +63,11 @@ properties:
   epoch:
     # epoch has no type since 1 is parsed as an int but 1* is a string
     description: the snap epoch, used to specify upgrade paths
-    pattern: "^[1-9][0-9]*[*]?$"
-    # This only affects integer values. Strings will be caught by pattern.
+    pattern: "^(?:0|[1-9][0-9]*[*]?)$"
+    # This only affects numeric values. Strings will be caught by pattern.
     minimum: 0
+    # This only affects numeric values. Strings will be caught by pattern.
+    multipleOf: 1.0
   apps:
     type: object
     additionalProperties: false

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -68,13 +68,8 @@ properties:
       - devmode
       - strict
   epoch:
-    # epoch has no type since 1 is parsed as an int but 1* is a string
     description: the snap epoch, used to specify upgrade paths
-    pattern: "^(?:0|[1-9][0-9]*[*]?)$"
-    # This only affects numeric values. Strings will be caught by pattern.
-    minimum: 0
-    # This only affects numeric values. Strings will be caught by pattern.
-    multipleOf: 1.0
+    format: epoch
   apps:
     type: object
     additionalProperties: false

--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -60,6 +60,12 @@ properties:
       - explicit
   license-version:
     description: license version (used to re-trigger an agreement action).
+  epoch:
+    # epoch has no type since 1 is parsed as an int but 1* is a string
+    description: the snap epoch, used to specify upgrade paths
+    pattern: "^[1-9][0-9]*[*]?$"
+    # This only affects integer values. Strings will be caught by pattern.
+    minimum: 0
   apps:
     type: object
     additionalProperties: false

--- a/snapcraft/_schema.py
+++ b/snapcraft/_schema.py
@@ -74,5 +74,7 @@ class Validator:
             if e.path:
                 messages.insert(0, "The '{}' property does not match the "
                                    "required schema:".format(e.path.pop()))
+            if e.cause:
+                messages.append('({})'.format(e.cause))
 
             raise SnapcraftSchemaError(' '.join(messages))

--- a/snapcraft/internal/meta.py
+++ b/snapcraft/internal/meta.py
@@ -44,6 +44,7 @@ _OPTIONAL_PACKAGE_KEYS = [
     'license-version',
     'plugs',
     'slots',
+    'epoch'
 ]
 
 _KERNEL_KEYS = {

--- a/snapcraft/internal/yaml.py
+++ b/snapcraft/internal/yaml.py
@@ -19,6 +19,7 @@ import contextlib
 import logging
 import os
 import os.path
+import re
 import sys
 
 import jsonschema
@@ -57,6 +58,21 @@ def _validate_icon(instance):
     if not os.path.exists(instance):
         raise jsonschema.exceptions.ValidationError(
             "Specified icon '{}' does not exist".format(instance))
+
+    return True
+
+
+class InvalidEpochError(Exception):
+    pass
+
+
+@jsonschema.FormatChecker.cls_checks('epoch', raises=InvalidEpochError)
+def _validate_epoch(instance):
+    str_instance = str(instance)
+    pattern = re.compile('^(?:0|[1-9][0-9]*[*]?)$')
+    if not pattern.match(str_instance):
+        raise InvalidEpochError(
+            "epochs are positive integers followed by an optional asterisk")
 
     return True
 

--- a/snapcraft/tests/test_meta.py
+++ b/snapcraft/tests/test_meta.py
@@ -79,6 +79,21 @@ class CreateTest(tests.TestCase):
         self.assertFalse('license' in y,
                          'license found in snap.yaml {}'.format(y))
 
+    def test_create_meta_with_epoch(self):
+        self.config_data['epoch'] = '1*'
+
+        create_snap_packaging(self.config_data, self.snap_dir, self.parts_dir)
+
+        self.assertTrue(
+            os.path.exists(self.snap_yaml), 'snap.yaml was not created')
+
+        with open(self.snap_yaml) as f:
+            y = yaml.load(f)
+        self.assertTrue(
+            'epoch' in y,
+            'Expected "epoch" property to be copied into snap.yaml')
+        self.assertEqual(y['epoch'], '1*')
+
     def test_create_meta_with_declared_license_and_setup(self):
         open(os.path.join(os.curdir, 'LICENSE'), 'w').close()
         self.config_data['license'] = 'LICENSE'

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -449,6 +449,79 @@ parts:
             'on line 2 of snapcraft.yaml')
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_yaml_valid_epochs(self, mock_loadPlugin):
+        valid_epochs = [
+            0,
+            '1*',
+            1,
+            '400*',
+            1234,
+        ]
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        for epoch in valid_epochs:
+            with self.subTest(key=epoch):
+                self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+epoch: {}
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""".format(epoch))
+                c = internal_yaml.Config()
+                self.assertEqual(c.data['epoch'], epoch)
+
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
+    def test_invalid_yaml_invalid_epochs(self, mock_loadPlugin):
+        invalid_epochs = [
+            '0*',
+            '_',
+            '1-',
+            '1+',
+            '-1',
+            '-1*',
+            'a',
+            '1a',
+            '1**',
+        ]
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        for epoch in invalid_epochs:
+            with self.subTest(key=epoch):
+                self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: nothing
+epoch: {}
+parts:
+  part1:
+    plugin: go
+    stage-packages: [fswebcam]
+""".format(epoch))
+                with self.assertRaises(SnapcraftSchemaError) as raised:
+                    internal_yaml.Config()
+
+                if 'less than' in raised.exception.message:
+                    self.assertEqual(
+                        raised.exception.message,
+                        "The 'epoch' property does not match the required "
+                        "schema: {} is less than the minimum of 0".format(
+                            epoch))
+                else:
+                    self.assertEqual(
+                        raised.exception.message,
+                        "The 'epoch' property does not match the required "
+                        "schema: '{}' does not match '^[1-9][0-9]*[*]?$'"
+                        .format(epoch))
+
+    @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_expands_filesets(self, mock_loadPlugin):
         self.make_snapcraft_yaml("""name: test
 version: "1"

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -597,10 +596,6 @@ parts:
                 'yaml': '0001',
                 'expected': 1,
             },
-            {
-                'yaml': 1.0,
-                'expected': 1,
-            },
         ]
 
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -636,6 +631,7 @@ parts:
             '"01"',
             '1.2',
             '"1.2"',
+            '[1]'
         ]
 
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -656,22 +652,11 @@ parts:
                 with self.assertRaises(SnapcraftSchemaError) as raised:
                     internal_yaml.Config()
 
-                if 'less than' in raised.exception.message:
-                    self.assertRegex(
-                        raised.exception.message,
-                        "The 'epoch' property does not match the required "
-                        "schema:.*is less than the minimum of 0")
-                elif 'not a multiple' in raised.exception.message:
-                    self.assertRegex(
-                        raised.exception.message,
-                        "The 'epoch' property does not match the required "
-                        "schema:.*is not a multiple of 1.0")
-                else:
-                    self.assertRegex(
-                        raised.exception.message,
-                        "The 'epoch' property does not match the required "
-                        "schema:.*does not match '{}'".format(
-                            re.escape('^(?:0|[1-9][0-9]*[*]?)$')))
+                self.assertRegex(
+                    raised.exception.message,
+                    "The 'epoch' property does not match the required "
+                    "schema:.*is not a 'epoch' \(epochs are positive integers "
+                    "followed by an optional asterisk\)")
 
     @unittest.mock.patch('snapcraft.internal.yaml.Config.load_plugin')
     def test_config_expands_filesets(self, mock_loadPlugin):


### PR DESCRIPTION
In order to support step upgrades, snaps need to be able to specify upgrade paths. This PR resolves LP: [#1581113](https://bugs.launchpad.net/snapcraft/+bug/1581113) by implementing that via a new "epoch" property specified in the `snap.yaml`. Valid epochs are positive integers (e.g. `0`, `1`, etc.) or positive integers followed by an asterisk (e.g. `1*`, `2*`, etc.).

`0` is epoch 0; `1*` is the upgrade path from 0 to 1; `1` is epoch 1 (and so on).