### PR TITLE
Reject plug/slot definitions at part level

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -163,12 +163,6 @@ properties:
             items:
               type: string
             default: ['*']
-          plugs:
-            type: object
-            description: used to connect to interfaces
-          slots:
-            type: object
-            description: used to offer interfaces
   plugs:
     type: object
   slots:


### PR DESCRIPTION
This patch removes incorrect schema entries that allow arbitrary plug
and slot definitions at a part level. Those definitions are ignored by
snapcraft but can cause potential confusion for users that read the
schema.

Fixes: https://bugs.launchpad.net/snapcraft/+bug/1581166
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>