### PR TITLE
Correct autotools documentation and tests to use configflags

### DIFF
--- a/docs/snapcraft-advanced-features.md
+++ b/docs/snapcraft-advanced-features.md
@@ -137,7 +137,7 @@ parts:
     my-part:
         plugin: autotools
         source: .
-        configFlags:
+        configflags:
             - --with-swig $SNAPCRAFT_STAGE/swig
         after:
             - swig

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -1887,7 +1887,7 @@ class StageEnvTestCase(tests.TestCase):
                     'SNAPCRAFT_STAGE/really',
                 ]
             },
-            'configFlags': [
+            'configflags': [
                 '--with-python',
                 '--with-swig $SNAPCRAFT_STAGE/swig',
             ],
@@ -1901,7 +1901,7 @@ class StageEnvTestCase(tests.TestCase):
                     'SNAPCRAFT_STAGE/really',
                 ]
             },
-            'configFlags': [
+            'configflags': [
                 '--with-python',
                 '--with-swig {}/swig'.format(self.stage_dir),
             ],


### PR DESCRIPTION
As discussed in #snappy IRC on Freenode with `sergiusens` at 13:41:02 on 26th May 2016, here is a pull request to correct the autotools plugin documentation and a couple of test cases.