### PR TITLE
Wrap plugin list output content

### DIFF
--- a/integration_tests/test_list_plugins.py
+++ b/integration_tests/test_list_plugins.py
@@ -21,21 +21,6 @@ class ListPluginsTestCase(integration_tests.TestCase):
 
     def test_list_plugins(self):
         output = self.run_snapcraft('list-plugins')
-        expected = ('ant\n'
-                    'autotools\n'
-                    'catkin\n'
-                    'cmake\n'
-                    'copy\n'
-                    'go\n'
-                    'jdk\n'
-                    'kbuild\n'
-                    'kernel\n'
-                    'make\n'
-                    'maven\n'
-                    'nil\n'
-                    'nodejs\n'
-                    'python2\n'
-                    'python3\n'
-                    'scons\n'
-                    'tar-content\n')
+        expected = ('ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
+                    'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
         self.assertEqual(expected, output)

--- a/integration_tests/test_list_plugins.py
+++ b/integration_tests/test_list_plugins.py
@@ -21,6 +21,8 @@ class ListPluginsTestCase(integration_tests.TestCase):
 
     def test_list_plugins(self):
         output = self.run_snapcraft('list-plugins')
-        expected = ('ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
-                    'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
+        expected = ('ant        catkin  copy  jdk     kernel  maven  '
+                    'nodejs   python3  tar-content\n'
+                    'autotools  cmake   go    kbuild  make    nil    '
+                    'python2  scons  \n')
         self.assertEqual(expected, output)

--- a/integration_tests/test_main.py
+++ b/integration_tests/test_main.py
@@ -22,7 +22,9 @@ class MainTestCase(integration_tests.TestCase):
     def test_main(self):
         project_dir = 'assemble'
         output = self.run_snapcraft('list-plugins', project_dir)
-        expected = ('ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
-                    'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
+        expected = ('ant        catkin  copy  jdk     kernel  maven  '
+                    'nodejs   python3  tar-content\n'
+                    'autotools  cmake   go    kbuild  make    nil    '
+                    'python2  scons  \n')
 
         self.assertEqual(expected, output)

--- a/integration_tests/test_main.py
+++ b/integration_tests/test_main.py
@@ -22,24 +22,7 @@ class MainTestCase(integration_tests.TestCase):
     def test_main(self):
         project_dir = 'assemble'
         output = self.run_snapcraft('list-plugins', project_dir)
-        expected_plugins = [
-            'ant',
-            'autotools',
-            'catkin',
-            'cmake',
-            'copy',
-            'go',
-            'jdk',
-            'kbuild',
-            'kernel',
-            'make',
-            'maven',
-            'nil',
-            'nodejs',
-            'python2',
-            'python3',
-            'scons',
-            'tar-content',
-        ]
+        expected = ('ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
+                    'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
 
-        self.assertIn('\n'.join(expected_plugins), output)
+        self.assertEqual(expected, output)

--- a/snapcraft/internal/common.py
+++ b/snapcraft/internal/common.py
@@ -35,6 +35,8 @@ _schemadir = _DEFAULT_SCHEMADIR
 _DEFAULT_LIBRARIESDIR = '/usr/share/snapcraft/libraries'
 _librariesdir = _DEFAULT_LIBRARIESDIR
 
+MAX_CHARACTERS_WRAP = 120
+
 env = []
 
 logger = logging.getLogger(__name__)

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -106,7 +106,8 @@ from docopt import docopt
 
 import snapcraft
 from snapcraft.internal import lifecycle, log
-from snapcraft.internal.common import MAX_CHARACTERS_WRAP
+from snapcraft.internal.common import (format_output_in_columns,
+                                       MAX_CHARACTERS_WRAP)
 
 
 logger = logging.getLogger(__name__)
@@ -134,8 +135,8 @@ def _list_plugins():
             command = ['tput', 'cols']
             width = min(int(subprocess.check_output(command)), width)
 
-    print(textwrap.fill("  ".join(plugins), width=width,
-                        break_on_hyphens=False))
+    for line in format_output_in_columns(plugins, max_width=width):
+        print(line)
 
 
 def _get_project_options(args):

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -133,7 +133,9 @@ def _list_plugins():
             # this is the only way to get current terminal size reliably
             # without duplicating a bunch of logic
             command = ['tput', 'cols']
-            width = min(int(subprocess.check_output(command)), width)
+            candidate_width = \
+                subprocess.check_output(command, stderr=subprocess.DEVNULL)
+            width = min(int(candidate_width), width)
 
     for line in format_output_in_columns(plugins, max_width=width):
         print(line)

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -26,8 +26,9 @@ class ListPluginsCommandTestCase(tests.TestCase):
 
     # plugin list when wrapper at MAX_CHARACTERS_WRAP
     default_plugin_output = (
-        'ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
-        'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
+        'ant        catkin  copy  jdk     kernel  maven  nodejs   python3  '
+        'tar-content\n'
+        'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     @mock.patch('subprocess.check_output')

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -26,8 +26,8 @@ class ListPluginsCommandTestCase(tests.TestCase):
 
     # plugin list when wrapper at MAX_CHARACTERS_WRAP
     default_plugin_output = (
-        "ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n"  # noqa
-        "autotools  cmake   go    kbuild  make    nil    python2  scons  \n")  # noqa
+        'ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n'  # noqa
+        'autotools  cmake   go    kbuild  make    nil    python2  scons  \n')  # noqa
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     @mock.patch('subprocess.check_output')
@@ -41,9 +41,9 @@ class ListPluginsCommandTestCase(tests.TestCase):
     def test_list_plugins_small_terminal(self, mock_subprocess, mock_stdout):
         mock_subprocess.return_value = "60"
         expected_output = (
-            "ant        cmake  jdk     make   nodejs   scons      \n"
-            "autotools  copy   kbuild  maven  python2  tar-content\n"
-            "catkin     go     kernel  nil    python3\n")
+            'ant        cmake  jdk     make   nodejs   scons      \n'
+            'autotools  copy   kbuild  maven  python2  tar-content\n'
+            'catkin     go     kernel  nil    python3\n')
         main(['list-plugins'])
         self.assertEqual(mock_stdout.getvalue(), expected_output)
 

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -25,9 +25,9 @@ from snapcraft import tests
 class ListPluginsCommandTestCase(tests.TestCase):
 
     # plugin list when wrapper at MAX_CHARACTERS_WRAP
-    default_plugin_output = ("ant  autotools  catkin  cmake  copy  go  jdk  " +
-                             "kbuild  kernel  make  maven  nil  nodejs  " +
-                             "python2  python3  scons\ntar-content\n")
+    default_plugin_output = (
+        "ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content\n"  # noqa
+        "autotools  cmake   go    kbuild  make    nil    python2  scons  \n")  # noqa
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     @mock.patch('subprocess.check_output')
@@ -40,11 +40,12 @@ class ListPluginsCommandTestCase(tests.TestCase):
     @mock.patch('subprocess.check_output')
     def test_list_plugins_small_terminal(self, mock_subprocess, mock_stdout):
         mock_subprocess.return_value = "60"
-        expected_list = ("ant  autotools  catkin  cmake  copy  go  jdk  " +
-                         "kbuild  kernel\nmake  maven  nil  nodejs  " +
-                         "python2  python3  scons\ntar-content\n")
+        expected_output = (
+            "ant        cmake  jdk     make   nodejs   scons      \n"
+            "autotools  copy   kbuild  maven  python2  tar-content\n"
+            "catkin     go     kernel  nil    python3\n")
         main(['list-plugins'])
-        self.assertEqual(mock_stdout.getvalue(), expected_list)
+        self.assertEqual(mock_stdout.getvalue(), expected_output)
 
     @mock.patch('sys.stdout', new_callable=io.StringIO)
     @mock.patch('subprocess.check_output')

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -51,7 +51,7 @@ class ListPluginsCommandTestCase(tests.TestCase):
     @mock.patch('subprocess.check_output')
     def test_list_plugins_error_invalid_terminal_size(self, mock_subprocess,
                                                       mock_stdout):
-        def raise_error(x):
+        def raise_error(cmd, stderr):
             raise OSError()
         mock_subprocess.side_effect = raise_error
         main(['list-plugins'])
@@ -61,8 +61,8 @@ class ListPluginsCommandTestCase(tests.TestCase):
     @mock.patch('subprocess.check_output')
     def test_list_plugins_error_invalid_subprocess_call(self, mock_subprocess,
                                                         mock_stdout):
-        def raise_error(x):
-            raise subprocess.CalledProcessError(returncode=1, cmd="foo")
+        def raise_error(cmd, stderr):
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
         mock_subprocess.side_effect = raise_error
         main(['list-plugins'])
         self.assertEqual(mock_stdout.getvalue(), self.default_plugin_output)

--- a/snapcraft/tests/test_commands_list_plugins.py
+++ b/snapcraft/tests/test_commands_list_plugins.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015 Canonical Ltd
+# Copyright (C) 2015-2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
+import subprocess
 from unittest import mock
 
 from snapcraft.main import main
@@ -23,25 +24,44 @@ from snapcraft import tests
 
 class ListPluginsCommandTestCase(tests.TestCase):
 
+    # plugin list when wrapper at MAX_CHARACTERS_WRAP
+    default_plugin_output = ("ant  autotools  catkin  cmake  copy  go  jdk  " +
+                             "kbuild  kernel  make  maven  nil  nodejs  " +
+                             "python2  python3  scons\ntar-content\n")
+
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_list_plugins(self, mock_stdout):
-        expected_list = '''ant
-autotools
-catkin
-cmake
-copy
-go
-jdk
-kbuild
-kernel
-make
-maven
-nil
-nodejs
-python2
-python3
-scons
-tar-content
-'''
+    @mock.patch('subprocess.check_output')
+    def test_list_plugins_large_terminal(self, mock_subprocess, mock_stdout):
+        mock_subprocess.return_value = "999"
+        main(['list-plugins'])
+        self.assertEqual(mock_stdout.getvalue(), self.default_plugin_output)
+
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    @mock.patch('subprocess.check_output')
+    def test_list_plugins_small_terminal(self, mock_subprocess, mock_stdout):
+        mock_subprocess.return_value = "60"
+        expected_list = ("ant  autotools  catkin  cmake  copy  go  jdk  " +
+                         "kbuild  kernel\nmake  maven  nil  nodejs  " +
+                         "python2  python3  scons\ntar-content\n")
         main(['list-plugins'])
         self.assertEqual(mock_stdout.getvalue(), expected_list)
+
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    @mock.patch('subprocess.check_output')
+    def test_list_plugins_error_invalid_terminal_size(self, mock_subprocess,
+                                                      mock_stdout):
+        def raise_error(x):
+            raise OSError()
+        mock_subprocess.side_effect = raise_error
+        main(['list-plugins'])
+        self.assertEqual(mock_stdout.getvalue(), self.default_plugin_output)
+
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    @mock.patch('subprocess.check_output')
+    def test_list_plugins_error_invalid_subprocess_call(self, mock_subprocess,
+                                                        mock_stdout):
+        def raise_error(x):
+            raise subprocess.CalledProcessError(returncode=1, cmd="foo")
+        mock_subprocess.side_effect = raise_error
+        main(['list-plugins'])
+        self.assertEqual(mock_stdout.getvalue(), self.default_plugin_output)

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -101,3 +101,45 @@ class CommonMigratedTestCase(tests.TestCase):
         self.assertEqual(
             str(raised.exception),
             "This plugin is outdated, use 'project.arch_triplet'")
+
+
+class FormatInColumnsTestCase(tests.TestCase):
+
+    elements_list = ["ant", "autotools", "catkin", "cmake", "copy", "go",
+                     "jdk", "kbuild", "kernel", "make", "maven", "nil",
+                     "nodejs", "python2", "python3", "scons", "tar-content"]
+
+    def test_format_output_in_columns_default(self):
+        '''Format output on 2 lines, with default max-width and space sep'''
+        expected = ['ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content',  # noqa
+                    'autotools  cmake   go    kbuild  make    nil    python2  scons  ']  # noqa
+        self.assertEquals(expected,
+                          common.format_output_in_columns(self.elements_list))
+
+    def test_format_output_in_columns_narrow(self):
+        '''Format output on 3 lines, with narrow max-width and space sep'''
+        expected = ['ant        cmake  jdk     make   nodejs   scons      ',
+                    'autotools  copy   kbuild  maven  python2  tar-content',
+                    'catkin     go     kernel  nil    python3']
+        self.assertEquals(expected,
+                          common.format_output_in_columns(self.elements_list,
+                                                          max_width=60))
+
+    def test_format_output_in_columns_large(self):
+        '''Format output on one big line, with default space sep'''
+        expected = ['ant  autotools  catkin  cmake  copy  go  jdk  kbuild  '
+                    'kernel  make  maven  nil  nodejs  python2  python3  '
+                    'scons  tar-content']
+        self.assertEquals(expected,
+                          common.format_output_in_columns(self.elements_list,
+                                                          max_width=990))
+
+    def test_format_output_in_columns_one_space(self):
+        '''Format output with one space sep'''
+        expected = ['ant       cmake jdk    make  nodejs  scons      ',
+                    'autotools copy  kbuild maven python2 tar-content',
+                    'catkin    go    kernel nil   python3']
+        self.assertEquals(expected,
+                          common.format_output_in_columns(self.elements_list,
+                                                          max_width=60,
+                                                          num_col_spaces=1))

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -111,8 +111,10 @@ class FormatInColumnsTestCase(tests.TestCase):
 
     def test_format_output_in_columns_default(self):
         """Format output on 2 lines, with default max-width and space sep"""
-        expected = ['ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content',  # noqa
-                    'autotools  cmake   go    kbuild  make    nil    python2  scons  ']  # noqa
+        expected = ['ant        catkin  copy  jdk     kernel  maven  '
+                    'nodejs   python3  tar-content',
+                    'autotools  cmake   go    kbuild  make    nil    '
+                    'python2  scons  ']
         self.assertEquals(expected,
                           common.format_output_in_columns(self.elements_list))
 

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -105,19 +105,19 @@ class CommonMigratedTestCase(tests.TestCase):
 
 class FormatInColumnsTestCase(tests.TestCase):
 
-    elements_list = ["ant", "autotools", "catkin", "cmake", "copy", "go",
-                     "jdk", "kbuild", "kernel", "make", "maven", "nil",
-                     "nodejs", "python2", "python3", "scons", "tar-content"]
+    elements_list = ['ant', 'autotools', 'catkin', 'cmake', 'copy', 'go',
+                     'jdk', 'kbuild', 'kernel', 'make', 'maven', 'nil',
+                     'nodejs', 'python2', 'python3', 'scons', 'tar-content']
 
     def test_format_output_in_columns_default(self):
-        '''Format output on 2 lines, with default max-width and space sep'''
+        """Format output on 2 lines, with default max-width and space sep"""
         expected = ['ant        catkin  copy  jdk     kernel  maven  nodejs   python3  tar-content',  # noqa
                     'autotools  cmake   go    kbuild  make    nil    python2  scons  ']  # noqa
         self.assertEquals(expected,
                           common.format_output_in_columns(self.elements_list))
 
     def test_format_output_in_columns_narrow(self):
-        '''Format output on 3 lines, with narrow max-width and space sep'''
+        """Format output on 3 lines, with narrow max-width and space sep"""
         expected = ['ant        cmake  jdk     make   nodejs   scons      ',
                     'autotools  copy   kbuild  maven  python2  tar-content',
                     'catkin     go     kernel  nil    python3']
@@ -126,7 +126,7 @@ class FormatInColumnsTestCase(tests.TestCase):
                                                           max_width=60))
 
     def test_format_output_in_columns_large(self):
-        '''Format output on one big line, with default space sep'''
+        """Format output on one big line, with default space sep"""
         expected = ['ant  autotools  catkin  cmake  copy  go  jdk  kbuild  '
                     'kernel  make  maven  nil  nodejs  python2  python3  '
                     'scons  tar-content']
@@ -135,7 +135,7 @@ class FormatInColumnsTestCase(tests.TestCase):
                                                           max_width=990))
 
     def test_format_output_in_columns_one_space(self):
-        '''Format output with one space sep'''
+        """Format output with one space sep"""
         expected = ['ant       cmake jdk    make  nodejs  scons      ',
                     'autotools copy  kbuild maven python2 tar-content',
                     'catkin    go    kernel nil   python3']


### PR DESCRIPTION
Wrap plugin list output content up to 120 characters depending on terminal size.

Added tests to ensure if detection fails, we are using the 120 characters. as well. Fixes https://bugs.launchpad.net/snapcraft/+bug/1587057.

Note that it's using put cols as a subprocess. A couple of years ago, I had to look into how to get the terminal size on different platforms in a reliable way, and it seems it's the best one without duplicating a fragile logic which evolves over time as new terminals arise.