### PR TITLE
Filter out *.snap from sourcedir

### DIFF
--- a/snapcraft/_baseplugin.py
+++ b/snapcraft/_baseplugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import glob
 import os
 import shutil
 
@@ -143,10 +144,19 @@ class BasePlugin:
         if os.path.exists(self.build_basedir):
             shutil.rmtree(self.build_basedir)
 
+        def ignore(directory, files):
+            if directory is self.sourcedir:
+                snaps = glob.glob(os.path.join(directory, '*.snap'))
+                if snaps:
+                    snaps = [os.path.basename(s) for s in snaps]
+                    return common.SNAPCRAFT_FILES + snaps
+                else:
+                    return common.SNAPCRAFT_FILES
+            else:
+                return []
+
         shutil.copytree(
-            self.sourcedir, self.build_basedir, symlinks=True,
-            ignore=lambda d, s: common.SNAPCRAFT_FILES
-            if d is self.sourcedir else [])
+            self.sourcedir, self.build_basedir, symlinks=True, ignore=ignore)
 
     def clean_build(self):
         """Clean the artifacts that resulted from building this part.

--- a/snapcraft/tests/test_base_plugin.py
+++ b/snapcraft/tests/test_base_plugin.py
@@ -189,21 +189,27 @@ class BuildTestCase(tests.TestCase):
     def test_build_ignores_snapcraft_files_in_source_dir(self):
         plugin = snapcraft.BasePlugin('test-part', options=None)
 
-        tmpdir = tempfile.TemporaryDirectory()
-        self.addCleanup(tmpdir.cleanup)
-        plugin.sourcedir = tmpdir.name
+        os.makedirs(plugin.sourcedir)
+        os.makedirs(plugin.builddir)
+
         for file_ in common.SNAPCRAFT_FILES:
             open(os.path.join(plugin.sourcedir, file_), 'w').close()
-
-        tmpdir = tempfile.TemporaryDirectory()
-        self.addCleanup(tmpdir.cleanup)
-        plugin.builddir = tmpdir.name
+        open(os.path.join(plugin.sourcedir, 'my-snap.snap'), 'w').close()
+        open(os.path.join(plugin.sourcedir, 'my-snap'), 'w').close()
 
         plugin.build()
 
         for file_ in common.SNAPCRAFT_FILES:
             self.assertFalse(
                 os.path.exists(os.path.join(plugin.builddir, file_)))
+        self.assertFalse(
+            os.path.exists(os.path.join(plugin.builddir, 'my-snap.snap')),
+            os.listdir(plugin.builddir))
+
+        # Make sure we don't filter things out incorrectly
+        self.assertTrue(
+            os.path.exists(os.path.join(plugin.builddir, 'my-snap')),
+            os.listdir(plugin.builddir))
 
 
 class CleanBuildTestCase(tests.TestCase):

--- a/snapcraft/tests/test_base_plugin.py
+++ b/snapcraft/tests/test_base_plugin.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import tempfile
 import unittest.mock
 
 import snapcraft


### PR DESCRIPTION
This filters out *.snap when in plugin.sourcedir.

LP: #1575628

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>