### PR TITLE
Use correct cross-build packages for ppc64le.

### DIFF
--- a/snapcraft/_options.py
+++ b/snapcraft/_options.py
@@ -46,8 +46,8 @@ _ARCH_TRANSLATIONS = {
     'ppc64le': {
         'kernel': 'powerpc',
         'deb': 'ppc64el',
-        'cross-compiler-prefix': 'gcc-powerpc64-linux-gnu-',
-        'cross-build-packages': ['gcc-powerpc64-linux-gnu'],
+        'cross-compiler-prefix': 'powerpc64le-linux-gnu-',
+        'cross-build-packages': ['gcc-powerpc64le-linux-gnu'],
         'triplet': 'powerpc64le-linux-gnu',
     },
     'x86_64': {


### PR DESCRIPTION
Snapcraft currently uses gcc-powerpc64-linux-gnu. This PR fixes LP: [#1570944](https://bugs.launchpad.net/snapcraft/+bug/1570944) by making it use gcc-powerpc64le-linux-gnu.