### PR TITLE
Reenable get and set tourdir unit tests

### DIFF
--- a/snapcraft/tests/__init__.py
+++ b/snapcraft/tests/__init__.py
@@ -49,7 +49,8 @@ class TestCase(testscenarios.WithScenarios, fixtures.TestWithFixtures):
         # value when a test ends.
         self.addCleanup(common.set_plugindir, common.get_plugindir())
         self.addCleanup(common.set_schemadir, common.get_schemadir())
-        self.addCleanup(common.set_schemadir, common.get_schemadir())
+        self.addCleanup(common.set_librariesdir, common.get_librariesdir())
+        self.addCleanup(common.set_tourdir, common.get_tourdir())
         self.addCleanup(common.reset_env)
         common.set_schemadir(os.path.join(__file__,
                              '..', '..', '..', 'schema'))

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -23,6 +23,14 @@ from snapcraft import tests
 
 class CommonTestCase(tests.TestCase):
 
+    def setUp(self):
+        super().setUp()
+        # reset all default paths
+        common._plugindir = common._DEFAULT_PLUGINDIR
+        common._schemadir = common._DEFAULT_SCHEMADIR
+        common._librariesdir = common._DEFAULT_LIBRARIESDIR
+        common._tourdir = common._DEFAULT_TOURDIR
+
     def test_get_default_plugindir(self):
         self.assertEqual(
             '/usr/share/snapcraft/plugins', common.get_plugindir())

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -25,7 +25,10 @@ class CommonTestCase(tests.TestCase):
 
     def setUp(self):
         super().setUp()
-        # reset all default paths
+        self.addCleanup(self._reset_default_paths)
+
+    def _reset_default_paths(self):
+        """Reset all default paths"""
         common._plugindir = common._DEFAULT_PLUGINDIR
         common._schemadir = common._DEFAULT_SCHEMADIR
         common._librariesdir = common._DEFAULT_LIBRARIESDIR

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -41,16 +41,10 @@ class CommonTestCase(tests.TestCase):
         self.assertEqual(plugindir, common.get_plugindir())
 
     def test_get_default_tourdir(self):
-        self.skipTest(
-            'This test is Failing in the launchpad builders. '
-            'Skipping while we find the reason.')
         self.assertEqual(
             '/usr/share/snapcraft/tour', common.get_tourdir())
 
     def test_set_tourdir(self):
-        self.skipTest(
-            'This test is Failing in the launchpad builders. '
-            'Skipping while we find the reason.')
         tourdir = os.path.join(self.path, 'testtour')
         common.set_tourdir(tourdir)
         self.assertEqual(tourdir, common.get_tourdir())

--- a/snapcraft/tests/test_common.py
+++ b/snapcraft/tests/test_common.py
@@ -23,17 +23,6 @@ from snapcraft import tests
 
 class CommonTestCase(tests.TestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.addCleanup(self._reset_default_paths)
-
-    def _reset_default_paths(self):
-        """Reset all default paths"""
-        common._plugindir = common._DEFAULT_PLUGINDIR
-        common._schemadir = common._DEFAULT_SCHEMADIR
-        common._librariesdir = common._DEFAULT_LIBRARIESDIR
-        common._tourdir = common._DEFAULT_TOURDIR
-
     def test_get_default_plugindir(self):
         self.assertEqual(
             '/usr/share/snapcraft/plugins', common.get_plugindir())


### PR DESCRIPTION
The existing tests (also for plugin dir) were running order dependant.
Ensure we reset the state to default for all internal variables.