### PR TITLE
Make the IsDirty unit test case pass in architectures other than amd64.

### DIFF
--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -40,6 +40,7 @@ class LXDTestCase(tests.TestCase):
 
         project_options = ProjectOptions()
         lxd.Cleanbuilder('snap.snap', 'project.tar', project_options).execute()
+        expected_arch = project_options.deb_arch
 
         self.assertEqual(
             'Setting up container with project assets\n'
@@ -51,7 +52,8 @@ class LXDTestCase(tests.TestCase):
         mock_call.assert_has_calls([
             call(['lxc', 'remote', 'add', 'my-pet',
                   'https://images.linuxcontainers.org:8443']),
-            call(['lxc', 'launch', 'my-pet:ubuntu/xenial/amd64',
+            call(['lxc', 'launch',
+                  'my-pet:ubuntu/xenial/{}'.format(expected_arch),
                   'snapcraft-my-pet']),
             call(['lxc', 'file', 'push', 'project.tar',
                   'snapcraft-my-pet//root/project.tar']),

--- a/snapcraft/tests/test_pluginhandler.py
+++ b/snapcraft/tests/test_pluginhandler.py
@@ -1030,8 +1030,7 @@ class IsDirtyTestCase(tests.TestCase):
         super().setUp()
 
         self.handler = pluginhandler.load_plugin(
-            'test-part', 'nil', project_options=snapcraft.ProjectOptions(
-                target_deb_arch='amd64'))
+            'test-part', 'nil', project_options=snapcraft.ProjectOptions())
         self.handler.makedirs()
 
     def test_prime_is_dirty(self):


### PR DESCRIPTION
Remove the architecture in the pluginhandler test case setup.

LP: #1589752