### PR TITLE
Make app names more restrictive.

### DIFF
--- a/schema/snapcraft.yaml
+++ b/schema/snapcraft.yaml
@@ -81,7 +81,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties:
-      "^[A-Za-z0-9:-]*$":
+      "^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$":
         type: object
         required:
           - command


### PR DESCRIPTION
Until recently snapd was too permissive on app names, allowing them to potentially cause issues in the system (e.g. interfering with hook names, or resulting in invalid AppArmor profile names, etc.). This has been changed in snapd, and this PR resolves LP: [#1589613](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1589613) by fixing it in snapcraft as well.

Note that this PR does not change the validation error when using an invalid app name, which is slightly dreadful, but requires a more in-depth refactor.