### PR TITLE
Backwards compatible clean with strip

### DIFF
--- a/integration_tests/test_clean_prime_step.py
+++ b/integration_tests/test_clean_prime_step.py
@@ -65,3 +65,19 @@ class CleanPrimeStepTestCase(integration_tests.TestCase):
         self.run_snapcraft('prime', self.project_dir)
         self.assertThat(os.path.join(bindir, 'file1'), FileExists())
         self.assertThat(os.path.join(bindir, 'file2'), FileExists())
+
+    def test_clean_with_deprecated_strip_step(self):
+        snapdir = os.path.join(self.project_dir, 'prime')
+        bindir = os.path.join(snapdir, 'bin')
+        self.assertThat(os.path.join(bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(bindir, 'file2'), FileExists())
+
+        self.run_snapcraft(['clean', '--step=strip'], self.project_dir)
+        self.assertThat(snapdir, Not(DirExists()))
+        self.assertThat(os.path.join(self.project_dir, 'stage'), DirExists())
+        self.assertThat(os.path.join(self.project_dir, 'parts'), DirExists())
+
+        # Now try to prime again
+        self.run_snapcraft('prime', self.project_dir)
+        self.assertThat(os.path.join(bindir, 'file1'), FileExists())
+        self.assertThat(os.path.join(bindir, 'file2'), FileExists())

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -228,7 +228,12 @@ def run(args, project_options):
     elif argless_command:
         argless_command()
     elif args['clean']:
-        lifecycle.clean(project_options, args['<part>'], args['--step'])
+        step = args['--step']
+        if args['--step'] == 'strip':
+            logger.warning('DEPRECATED: Use `prime` instead of `strip` '
+                           'as the step to clean')
+            step = 'prime'
+        lifecycle.clean(project_options, args['<part>'], step)
     elif args['upload']:
         snapcraft.upload(args['<snap-file>'])
     elif args['cleanbuild']:

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -229,7 +229,7 @@ def run(args, project_options):
         argless_command()
     elif args['clean']:
         step = args['--step']
-        if args['--step'] == 'strip':
+        if step == 'strip':
             logger.warning('DEPRECATED: Use `prime` instead of `strip` '
                            'as the step to clean')
             step = 'prime'

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -14,10 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import shutil
 
 from unittest import mock
+
+import fixtures
 
 from snapcraft.main import main
 from snapcraft.internal import (
@@ -166,6 +169,31 @@ parts:
         mock_clean.assert_called_with(
             expected_staged_state, expected_primed_state, 'foo')
 
+    @mock.patch.object(pluginhandler.PluginHandler, 'clean')
+    def test_cleaning_with_strip_does_prime_and_warns(self, mock_clean):
+        fake_logger = fixtures.FakeLogger(level=logging.WARNING)
+        self.useFixture(fake_logger)
+
+        self.make_snapcraft_yaml(n=3)
+
+        main(['clean', '--step=strip'])
+
+        expected_staged_state = {
+            'clean0': states.StageState({'clean0'}, set()),
+            'clean1': states.StageState({'clean1'}, set()),
+            'clean2': states.StageState({'clean2'}, set()),
+        }
+
+        expected_primed_state = {
+            'clean0': states.PrimeState({'clean0'}, set()),
+            'clean1': states.PrimeState({'clean1'}, set()),
+            'clean2': states.PrimeState({'clean2'}, set()),
+        }
+
+        self.assertEqual('DEPRECATED: Use `prime` instead of `strip` as '
+                         'the step to clean\n', fake_logger.output)
+        mock_clean.assert_called_with(
+            expected_staged_state, expected_primed_state, 'prime')
 
 class CleanCommandReverseDependenciesTestCase(tests.TestCase):
 

--- a/snapcraft/tests/test_commands_clean.py
+++ b/snapcraft/tests/test_commands_clean.py
@@ -195,6 +195,7 @@ parts:
         mock_clean.assert_called_with(
             expected_staged_state, expected_primed_state, 'prime')
 
+
 class CleanCommandReverseDependenciesTestCase(tests.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Automatically switches to call in prime and prints a
deprecation warning.

LP: #1590256

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>