### PR TITLE
Reenable tour command

### DIFF
--- a/integration_tests/test_tour.py
+++ b/integration_tests/test_tour.py
@@ -1,0 +1,43 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2016 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import integration_tests
+import os
+
+class TourTestCase(integration_tests.TestCase):
+
+    def test_tour_no_arg(self):
+        output = self.run_snapcraft('tour')
+        self.assertTrue(os.path.isdir('snapcraft-tour'),
+                        'Tour directory was created')
+        self.assertIn('Snapcraft tour initialized in ./snapcraft-tour/',
+                      output)
+
+    def test_tour_with_relative_dir(self):
+        dest_dir = 'foo'
+        output = self.run_snapcraft(['tour', dest_dir])
+        self.assertTrue(os.path.isdir(dest_dir),
+                        'Tour directory was created')
+        self.assertIn('Snapcraft tour initialized in {}'.format(dest_dir),
+                      output)
+
+    def test_tour_with_absolute_dir(self):
+        dest_dir = os.path.abspath('foo')
+        output = self.run_snapcraft(['tour', dest_dir])
+        self.assertTrue(os.path.isdir(dest_dir),
+                        'Tour directory was created')
+        self.assertIn('Snapcraft tour initialized in {}'.format(dest_dir),
+                      output)

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -33,6 +33,7 @@ Usage:
   snapcraft [options] logout
   snapcraft [options] upload <snap-file>
   snapcraft [options] list-plugins
+  snapcraft [options] tour [<directory>]
   snapcraft [options] help (topics | <plugin> | <topic>) [--devel]
   snapcraft (-h | --help)
   snapcraft --version
@@ -70,6 +71,8 @@ The available commands are:
   list-plugins List the available plugins that handle different types of part.
   login        Authenticate session against Ubuntu One SSO.
   logout       Clear session credentials.
+  tour         Setup the snapcraft examples tour in the specified directory,
+               or ./snapcraft-tour/.
   upload       Upload a snap to the Ubuntu Store.
 
 The available lifecycle commands are:
@@ -238,9 +241,8 @@ def run(args, project_options):
         snapcraft.upload(args['<snap-file>'])
     elif args['cleanbuild']:
         lifecycle.cleanbuild(project_options),
-    # disable until the tour command is activated
-    # elif args['tour']:
-    #    _scaffold_examples(args['<directory>'] or _SNAPCRAFT_TOUR_DIR)
+    elif args['tour']:
+        _scaffold_examples(args['<directory>'] or _SNAPCRAFT_TOUR_DIR)
     elif args['help']:
         snapcraft.topic_help(args['<topic>'] or args['<plugin>'],
                              args['--devel'], args['topics'])

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -117,7 +117,7 @@ from snapcraft.internal.common import (
 
 
 logger = logging.getLogger(__name__)
-_SNAPCRAFT_TOUR_DIR = "snapcraft-tour"
+_SNAPCRAFT_TOUR_DIR = "./snapcraft-tour/"
 
 
 def _get_version():
@@ -143,7 +143,7 @@ def _scaffold_examples(directory):
         dest_dir = os.path.join(dest_dir, _SNAPCRAFT_TOUR_DIR)
         shutil.copytree(get_tourdir(), dest_dir)
 
-    print("Snapcraft tour initialized in {}.\n"
+    print("Snapcraft tour initialized in {}\n"
           "Instructions are in the README, or "
           "https://snapcraft.io/create/#begin".format(directory))
 

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -145,7 +145,8 @@ def _scaffold_examples(directory):
         if not os.path.isdir(dest_dir):
             raise NotADirectoryError("{} is a file, can't be used as a "
                                      "destination".format(dest_dir))
-        dest_dir = os.path.join(dest_dir, _SNAPCRAFT_TOUR_DIR)
+        dest_dir = os.path.normpath(os.path.join(dest_dir,
+                                                 _SNAPCRAFT_TOUR_DIR))
         shutil.copytree(get_tourdir(), dest_dir)
 
     print("Snapcraft tour initialized in {}\n"

--- a/snapcraft/main.py
+++ b/snapcraft/main.py
@@ -132,10 +132,15 @@ def _scaffold_examples(directory):
     dest_dir = os.path.abspath(directory)
 
     # If dest_dir doesn't exist, we dump all examples in it.
-    # If it does exist, we dump them into a subdirectory
+    # If it does exist, we dump them into a subdirectory if it's not
+    # the default dir.
     try:
         shutil.copytree(get_tourdir(), dest_dir)
     except FileExistsError:
+        # default crafted directory shouldn't add itself inside
+        if directory == _SNAPCRAFT_TOUR_DIR:
+            raise FileExistsError("{} already exists, please specify a "
+                                  "destination directory.".format(directory))
         # don't event try to copy if the dest exists already
         if not os.path.isdir(dest_dir):
             raise NotADirectoryError("{} is a file, can't be used as a "

--- a/snapcraft/tests/test_tour.py
+++ b/snapcraft/tests/test_tour.py
@@ -46,31 +46,20 @@ class TestExamplesCmd(TestCase):
 
 class TestScaffoldExample(TestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.temp_dir = None
-        self.cwd = os.getcwd()
-
-    def tearDown(self):
-        with suppress(OSError):
-            if self.temp_dir:
-                shutil.rmtree(self.temp_dir)
-        os.chdir(self.cwd)
-        super().tearDown()
-
     @mock.patch('snapcraft.main.get_tourdir')
     def test_copy_example_unexisting_path(self, mock_get_tourdir):
         mock_get_tourdir.return_value = \
             os.path.join(os.path.dirname(__file__), '..', '..', 'tour')
-        self.temp_dir = mktemp()
-        snapcraft.main._scaffold_examples(self.temp_dir)
+        dest_path = os.path.join(self.path, 'foo')
+        snapcraft.main._scaffold_examples(dest_path)
 
-        self.assertTrue(os.path.isdir(self.temp_dir), "dest path exists")
+        self.assertTrue(os.path.isdir(dest_path), "dest path exists")
 
     @mock.patch('snapcraft.main.get_tourdir')
     def test_copy_example_existing_path(self, mock_get_tourdir):
         mock_get_tourdir.return_value = \
             os.path.join(os.path.dirname(__file__), '..', '..', 'tour')
+        # we create a path which isn't cwd
         with TemporaryDirectory() as temp_dir:
             snapcraft.main._scaffold_examples(temp_dir)
 
@@ -83,15 +72,13 @@ class TestScaffoldExample(TestCase):
     def test_copy_example_existing_default_path(self, mock_get_tourdir):
         mock_get_tourdir.return_value = \
             os.path.join(os.path.dirname(__file__), '..', '..', 'tour')
-        with TemporaryDirectory() as temp_dir:
-            # we create assets with default name in cwd
-            os.chdir(temp_dir)
-            default_dir = snapcraft.main._SNAPCRAFT_TOUR_DIR
-            os.makedirs(default_dir)
+        # we create the default dir name in cwd
+        default_dir = snapcraft.main._SNAPCRAFT_TOUR_DIR
+        os.makedirs(default_dir)
 
-            self.assertRaises(FileExistsError,
-                              snapcraft.main._scaffold_examples,
-                              default_dir)
+        self.assertRaises(FileExistsError,
+                          snapcraft.main._scaffold_examples,
+                          default_dir)
 
     @mock.patch('snapcraft.main.get_tourdir')
     def test_copy_example_on_existing_file(self, mock_get_tourdir):

--- a/snapcraft/tests/test_tour.py
+++ b/snapcraft/tests/test_tour.py
@@ -49,11 +49,13 @@ class TestScaffoldExample(TestCase):
     def setUp(self):
         super().setUp()
         self.temp_dir = None
+        self.cwd = os.getcwd()
 
     def tearDown(self):
         with suppress(OSError):
             if self.temp_dir:
                 shutil.rmtree(self.temp_dir)
+        os.chdir(self.cwd)
         super().tearDown()
 
     @mock.patch('snapcraft.main.get_tourdir')
@@ -76,6 +78,20 @@ class TestScaffoldExample(TestCase):
             dest_path = os.path.join(temp_dir, "snapcraft-tour")
 
             self.assertTrue(os.path.isdir(dest_path), "dest path exists: {}")
+
+    @mock.patch('snapcraft.main.get_tourdir')
+    def test_copy_example_existing_default_path(self, mock_get_tourdir):
+        mock_get_tourdir.return_value = \
+            os.path.join(os.path.dirname(__file__), '..', '..', 'tour')
+        with TemporaryDirectory() as temp_dir:
+            # we create assets with default name in cwd
+            os.chdir(temp_dir)
+            default_dir = snapcraft.main._SNAPCRAFT_TOUR_DIR
+            os.makedirs(default_dir)
+
+            self.assertRaises(FileExistsError,
+                              snapcraft.main._scaffold_examples,
+                              default_dir)
 
     @mock.patch('snapcraft.main.get_tourdir')
     def test_copy_example_on_existing_file(self, mock_get_tourdir):

--- a/snapcraft/tests/test_tour.py
+++ b/snapcraft/tests/test_tour.py
@@ -14,11 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from contextlib import suppress
 import os
-import shutil
 import sys
-from tempfile import mktemp, TemporaryDirectory, NamedTemporaryFile
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from unittest import mock
 
 import snapcraft.main

--- a/snapcraft/tests/test_tour.py
+++ b/snapcraft/tests/test_tour.py
@@ -29,7 +29,6 @@ from snapcraft.tests import TestCase
 class TestExamplesCmd(TestCase):
 
     def test_call_scaffold_with_parameter(self):
-        return  # disabled until the tour command is activated
         sys.argv = ['/usr/bin/snapcraft', 'tour', '/tmp/foo']
 
         with mock.patch('snapcraft.main._scaffold_examples') as mock_cmd:
@@ -37,7 +36,6 @@ class TestExamplesCmd(TestCase):
             mock_cmd.assert_called_once_with("/tmp/foo")
 
     def test_call_scaffold_without_parameter(self):
-        return  # disabled until the tour command is activated
         sys.argv = ['/usr/bin/snapcraft', 'tour']
 
         with mock.patch('snapcraft.main._scaffold_examples') as mock_cmd:


### PR DESCRIPTION
Reenable "snapcraft tour" command with tests.

Added a small logic enhancements backed up with tests to ensure we don't nest default directory inside each other for multiple commands run.