### PR TITLE
Revert "Fix missing python-magic dependency"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
             ['libraries/' + x for x in os.listdir('libraries')]),
     ],
     install_requires=[
-        'file-magic',
         'pyxdg',
         'requests',
         'requests-oauthlib',


### PR DESCRIPTION
Reverts ubuntu-core/snapcraft#435

This affecting package builds.