### PR TITLE
Make lxd containers ephemeral

### DIFF
--- a/snapcraft/internal/lxd.py
+++ b/snapcraft/internal/lxd.py
@@ -61,7 +61,7 @@ class Cleanbuilder:
             remote_tmp = petname.Generate(2, '-')
             check_call(['lxc', 'remote', 'add', remote_tmp, self._server])
             check_call([
-                'lxc', 'launch',
+                'lxc', 'launch', '-e',
                 '{}:ubuntu/xenial/{}'.format(
                     remote_tmp, self._project_options.deb_arch),
                 self._container_name])

--- a/snapcraft/tests/test_lxd.py
+++ b/snapcraft/tests/test_lxd.py
@@ -52,7 +52,7 @@ class LXDTestCase(tests.TestCase):
         mock_call.assert_has_calls([
             call(['lxc', 'remote', 'add', 'my-pet',
                   'https://images.linuxcontainers.org:8443']),
-            call(['lxc', 'launch',
+            call(['lxc', 'launch', '-e',
                   'my-pet:ubuntu/xenial/{}'.format(expected_arch),
                   'snapcraft-my-pet']),
             call(['lxc', 'file', 'push', 'project.tar',


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/snapcraft/+bug/1577548