### PR TITLE
Support for a hidden snapcraft.yaml

### DIFF
--- a/snapcraft/internal/yaml.py
+++ b/snapcraft/internal/yaml.py
@@ -516,14 +516,14 @@ def _expand_filesets_for(step, properties):
 
 
 def _get_snapcraft_yaml():
-    unhidden_yaml_exists = os.path.exists('snapcraft.yaml')
+    visible_yaml_exists = os.path.exists('snapcraft.yaml')
     hidden_yaml_exists = os.path.exists('.snapcraft.yaml')
 
-    if unhidden_yaml_exists and hidden_yaml_exists:
+    if visible_yaml_exists and hidden_yaml_exists:
         raise EnvironmentError(
             "Found a 'snapcraft.yaml' and a '.snapcraft.yaml', "
             "please remove one")
-    elif unhidden_yaml_exists:
+    elif visible_yaml_exists:
         return 'snapcraft.yaml'
     elif hidden_yaml_exists:
         return '.snapcraft.yaml'

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -835,7 +835,7 @@ parts:
         os.rename('snapcraft.yaml', '.snapcraft.yaml')
         internal_yaml.Config()
 
-    def test_unhidden_snapcraft_yaml_loads(self):
+    def test_visible_snapcraft_yaml_loads(self):
         self.make_snapcraft_yaml("""name: test
 version: "1"
 summary: test

--- a/snapcraft/tests/test_yaml.py
+++ b/snapcraft/tests/test_yaml.py
@@ -38,6 +38,12 @@ class TestYaml(tests.TestCase):
         super().setUp()
         dirs.setup_dirs()
 
+        patcher = unittest.mock.patch(
+            'snapcraft.internal.yaml._get_snapcraft_yaml')
+        self.mock_get_yaml = patcher.start()
+        self.mock_get_yaml.return_value = 'snapcraft.yaml'
+        self.addCleanup(patcher.stop)
+
         patcher = unittest.mock.patch('os.path.exists')
         self.mock_path_exists = patcher.start()
         self.mock_path_exists.return_value = True
@@ -261,17 +267,6 @@ parts:
         config = internal_yaml.Config(ProjectOptionsFake())
 
         self.assertEqual(config.build_tools, [])
-
-    def test_config_raises_on_missing_snapcraft_yaml(self):
-        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
-        self.useFixture(fake_logger)
-
-        # no snapcraft.yaml
-        with self.assertRaises(
-                snapcraft.internal.yaml.SnapcraftYamlFileError) as raised:
-            internal_yaml.Config()
-
-        self.assertEqual(raised.exception.file, 'snapcraft.yaml')
 
     def test_config_loop(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
@@ -795,6 +790,64 @@ parts:
 
         self.assertFalse(config.part_dependents('dependent'))
         self.assertEqual({'dependent'}, config.part_dependents('main'))
+
+
+class InitTestCase(tests.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+    def test_config_raises_on_missing_snapcraft_yaml(self):
+        # no snapcraft.yaml
+        with self.assertRaises(
+                snapcraft.internal.yaml.SnapcraftYamlFileError) as raised:
+            internal_yaml.Config()
+
+        self.assertEqual(raised.exception.file, 'snapcraft.yaml')
+
+    def test_two_snapcraft_yamls_cuase_error(self):
+        open('snapcraft.yaml', 'w').close()
+        open('.snapcraft.yaml', 'w').close()
+
+        with self.assertRaises(EnvironmentError) as raised:
+            internal_yaml.Config()
+
+        self.assertEqual(
+            str(raised.exception),
+            "Found a 'snapcraft.yaml' and a '.snapcraft.yaml', "
+            "please remove one")
+
+    def test_hidden_snapcraft_yaml_loads(self):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+
+parts:
+  main:
+    plugin: nil
+""")
+
+        os.rename('snapcraft.yaml', '.snapcraft.yaml')
+        internal_yaml.Config()
+
+    def test_unhidden_snapcraft_yaml_loads(self):
+        self.make_snapcraft_yaml("""name: test
+version: "1"
+summary: test
+description: test
+confinement: strict
+
+parts:
+  main:
+    plugin: nil
+""")
+
+        internal_yaml.Config()
 
 
 class TestYamlEnvironment(tests.TestCase):


### PR DESCRIPTION
Adding support for .snapcraft.yaml and erroring out if both a
.snapcraft.yaml and a snapcraft.yaml are found.

`snapcraft init` will still create an unhidden one.

LP: #1587933

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>