### PR TITLE
Update the remote parts cache before demo tests

### DIFF
--- a/snaps_tests/demos_tests/test_mosquitto.py
+++ b/snaps_tests/demos_tests/test_mosquitto.py
@@ -24,7 +24,7 @@ class MosquittoTestCase(snaps_tests.SnapsTestCase):
     snap_content_dir = 'mosquitto'
 
     def test_mosquitto(self):
-        self.build_snap(self.snap_content_dir)
+        self.build_snap(self.snap_content_dir, update_cache=True)
         snap_name = 'mosquitto'
         self.install_snap(self.snap_content_dir, snap_name, '0.1')
         self.assert_service_running(snap_name, 'mosquitto')

--- a/snaps_tests/demos_tests/test_qt4_text_editor.py
+++ b/snaps_tests/demos_tests/test_qt4_text_editor.py
@@ -22,7 +22,7 @@ class Qt4TextEditorTestCase(snaps_tests.SnapsTestCase):
     snap_content_dir = 'qt4-text-editor'
 
     def test_text_editor(self):
-        self.build_snap(self.snap_content_dir)
+        self.build_snap(self.snap_content_dir, update_cache=True)
         self.install_snap(
             self.snap_content_dir, 'text-editor', '1.0')
 

--- a/snaps_tests/demos_tests/test_qt5_text_editor.py
+++ b/snaps_tests/demos_tests/test_qt5_text_editor.py
@@ -22,7 +22,7 @@ class Qt5TextEditorTestCase(snaps_tests.SnapsTestCase):
     snap_content_dir = 'qt5-text-editor'
 
     def test_text_editor(self):
-        self.build_snap(self.snap_content_dir)
+        self.build_snap(self.snap_content_dir, update_cache=True)
         self.install_snap(
             self.snap_content_dir, 'text-editor', '1.0')
 


### PR DESCRIPTION
Make sure the cache is updated for the following demos:

- mosquitto
- qt4 text editor
- qt5 text editor

LP: #1596114

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>