### PR TITLE
Simplify the list plugins integration test

### DIFF
--- a/integration_tests/test_list_plugins.py
+++ b/integration_tests/test_list_plugins.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2015-2016 Canonical Ltd
+# Copyright (C) 2015, 2016 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,15 +14,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pkgutil
+
+from snapcraft import plugins
+
 import integration_tests
+
+from testtools.matchers import HasLength
 
 
 class ListPluginsTestCase(integration_tests.TestCase):
 
     def test_list_plugins(self):
         output = self.run_snapcraft('list-plugins')
-        expected = (
-            'ant        cmake  gulp    kernel  nil      python3  tar-content\n'
-            'autotools  copy   jdk     make    nodejs   qmake  \n'
-            'catkin     go     kbuild  maven   python2  scons  \n')
-        self.assertEqual(expected, output)
+        expected = [
+            module_name.replace('_', '-') for _, module_name, _ in
+            pkgutil.iter_modules(plugins.__path__)
+        ]
+        for plugin in expected:
+            self.assertIn(plugin, output)
+        self.assertThat(output.split(), HasLength(len(expected)))


### PR DESCRIPTION
This test has been unnecessarily painful to maintain, because every time
we add a new plugin, the format is changed. We don't need to check the format
anymore, and there is little risk of this breaking because the mechanism has been
extensively tested already.

LP: #1596114